### PR TITLE
Add Django Admin integration

### DIFF
--- a/backend/uclapi/dashboard/admin.py
+++ b/backend/uclapi/dashboard/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
 
 # Register your models here.
-from models import WhiteList
+from .models import WhiteList
 admin.site.register(WhiteList)


### PR DESCRIPTION
Pls review @abdulfaizp 

@ChristopherHammond13 this requires us to make a user account that allows us to access django admin at /admin/. Details here: https://docs.djangoproject.com/en/1.10/ref/django-admin/#createsuperuser