### PR TITLE
Make AWS and Production Ready

### DIFF
--- a/backend/uclapi/.env.example
+++ b/backend/uclapi/.env.example
@@ -10,6 +10,18 @@ SECRET_KEY=
 # To test using fakeshibboleth, use the value http://localhost:8001
 SHIBBOLETH_ROOT=
 
+# Whether we are running in production. This defines whether we have debug enabled, etc.
+UCLAPI_PRODUCTION=True
+
+# The domain we are running on. This is used by Django's ALLOWED_HOSTS feature
+UCLAPI_DOMAIN=uclapi.com
+
+# Whether we are running behind Amazon's EC2 Elastic Load Balancer. If so, this
+# switches on a feature to fetch the local ipv4 address assigned by EC2 so that
+# health checks and internal connections work as intended.
+# See https://dryan.com/articles/elb-django-allowed-hosts/ for more info.
+UCLAPI_RUNNING_ON_AWS_ELB=False
+
 ### UCLAPI DB Settings
 ## These should be for your PostgreSQL backend.
 

--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -8,4 +8,5 @@ djangorestframework==3.5.3
 opbeat==3.5.2
 psycopg2==2.6.2
 raven==5.32.0
+requests==2.13.0
 urllib3==1.20


### PR DESCRIPTION
Make AWS Ready by setting debug based on a production environment variable, and add functionality to set local IP address as an allowed host by reading it from Amazon's internal API if running on an Elastic Load Balancer.

Please check that this works okay! It should be fine but I'm not great with Python so I'd appreciate a review :)

This article is linked to in the new .env example but it's worth posting in these comments too: https://dryan.com/articles/elb-django-allowed-hosts/