### PR TITLE
object_hook to convert datetime string to the object while obtaining …

### DIFF
--- a/backend/uclapi/roombookings/models.py
+++ b/backend/uclapi/roombookings/models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from .api_helpers import generate_token
 import json
+import datetime
 
 
 class Booking(models.Model):
@@ -76,4 +77,12 @@ class PageToken(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
 
     def get_query(self):
-        return json.loads(self.query)
+        def date_hook(json_dict):
+            for (key, value) in json_dict.items():
+                try:
+                    json_dict[key] = datetime.datetime.strptime(
+                        value, "%Y-%m-%d %H:%M:%S")
+                except:
+                    pass
+            return json_dict
+        return json.loads(self.query, object_hook=date_hook)

--- a/backend/uclapi/roombookings/views.py
+++ b/backend/uclapi/roombookings/views.py
@@ -25,7 +25,6 @@ def get_rooms(request):
     request_params['capacity__gte'] = request.GET.get('capacity')
     request_params['automated'] = request.GET.get('automated')
 
-
     # webview available rooms
     all_rooms = Room.objects.using("roombookings").filter(
             setid='LIVE-16-17',


### PR DESCRIPTION
…it from the database

@jermenkoo @xoneco I couldn't reproduce the sentry 500 with the same query. So I am guessing the error is because datetimes dont get decoded in to a datetime format when i take query params from the database. hence the [object hook](http://stackoverflow.com/a/16310732/5556675).
