### PR TITLE
Fix description field

### DIFF
--- a/backend/uclapi/roombookings/views.py
+++ b/backend/uclapi/roombookings/views.py
@@ -67,7 +67,7 @@ def get_bookings(request):
     # TODO: building?
     request_params['siteid'] = request.GET.get('siteid')
     request_params['roomname'] = request.GET.get('roomname')
-    request_params['description'] = request.GET.get('description')
+    request_params['descrip'] = request.GET.get('description')
     request_params['condisplayname__contains'] = request.GET.get('contact')
     request_params['startdatetime'] = request.GET.get('date')
     # 20 is the default number of bookings per page


### PR DESCRIPTION
Right now supplying the `descrip` parameter leaves you with a `500` error. This PR fixes that.