### PR TITLE
Adding codecov.io (coverage) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 cache: pip
 install:
   - (sed '/cx.*/d' ./backend/uclapi/requirements.txt) | xargs -n 1 pip3 install
-  - pip3 install pylint
+  - pip3 install codecov coverage prospector pylint pylint-django
 services:
   - postgresql
 script:
@@ -23,20 +23,17 @@ script:
   - export LD_LIBRARY_PATH=$ORACLE_HOME
   - env ARCHFLAGS="-arch x86_64"
   # Install cx_Oracle (which depends on Oracle IC)
-  - ls $ORACLE_HOME
-  - pip3 install cx_Oracle==5.2.1
-  # Let's test this baby
   - cd ./backend/uclapi
+  - pip3 install $(cat requirements.txt | grep "cx-Oracle")
+  # Let's test this baby
   - touch .env
   - python ./manage.py migrate
-  - python ./manage.py test --testrunner 'roombookings.custom_test_runner.NoDbTestRunner'
+  # codecov.io
+  - coverage run --source='.' manage.py test --testrunner 'roombookings.custom_test_runner.NoDbTestRunner'
   # Linting
-  - pip3 install pylint
   - pylint $(find . -name "*.py" -print) > pylint.log || (($? != 1))
   # Succeeds as long as score > 7
   - echo "$(tail -n 2 pylint.log | head -n 1 | egrep '([0-9]*\.[0-9]+|[0-9]+)' -ho | head -n 1) <= 7" | bc
-  - pip3 install prospector pylint-django
   - echo "$(prospector --uses django | grep 'Messages Found.*' | egrep -ho '[[:digit:]]+') > 50" | bc || (($? == 0))
-  # codecov.io
-  - pip3 install codecov
+after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - touch .env
   - python ./manage.py migrate
   # codecov.io
-  - coverage run --source='.' manage.py test --testrunner 'roombookings.custom_test_runner.NoDbTestRunner'
+  - coverage run --source='.' --omit='*migrations*' manage.py test --testrunner 'roombookings.custom_test_runner.NoDbTestRunner'
   # Linting
   - pylint $(find . -name "*.py" -print) > pylint.log || (($? != 1))
   # Succeeds as long as score > 7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uclapi
+# uclapi [![Build Status](https://travis-ci.org/uclapi/uclapi.svg?branch=master)](https://travis-ci.org/uclapi/uclapi) [![codecov](https://codecov.io/gh/uclapi/uclapi/branch/master/graph/badge.svg)](https://codecov.io/gh/uclapi/uclapi)
 UCL API Main Repository
 
 ## Testing


### PR DESCRIPTION
## What does this PR do?
This PR changes 2 (+1) things:

* adds codecov.io support to measure coverage of the codebase
* adds build badges (TravisCI, codecov) into README.md
* installs cx-Oracle from requirements.txt (as previously the version was hard-coded to 5.2.1 - the version before upgrade of requirements.txt)

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?

## 📃 Link to PR updating documentation (if applicable)

https://github.com/uclapi/apiDocs/pulls

## 🚨 Is this a breaking change for API clients?
No.

## :squirrel: Deploy notes
No.

## Anything else
The badges (esp. Travis CI) should get updated once merged into `master` branch.