### PR TITLE
pretty formatting JsonResponse

### DIFF
--- a/backend/uclapi/roombookings/helpers.py
+++ b/backend/uclapi/roombookings/helpers.py
@@ -11,6 +11,10 @@ import pytz
 from datetime import timedelta
 import ciso8601
 
+class PrettyJsonResponse(JsonResponse):
+    def __init__(self, data):
+        super().__init__(data, json_dumps_params={'indent': 4})
+
 
 def _create_page_token(query, pagination):
     page = PageToken(

--- a/backend/uclapi/roombookings/tests.py
+++ b/backend/uclapi/roombookings/tests.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 from itertools import chain
 import datetime
 
-from .helpers import _serialize_rooms, _serialize_equipment, _parse_datetime
+from .helpers import _serialize_rooms, _serialize_equipment, _parse_datetime, PrettyJsonResponse
 from .models import Room
 
 
@@ -117,3 +117,8 @@ class ParseDateTimeTestCase(SimpleTestCase):
                 expected[index],
                 _parse_datetime(args[0], args[1], args[2])
             )
+
+class PrettyPrintJsonTestCase(SimpleTestCase):
+    def test_pretty_print(self):
+        response = PrettyJsonResponse({"foo":"bar"})
+        self.assertEqual(response.content.decode(), '{\n    "foo": "bar"\n}')

--- a/backend/uclapi/roombookings/views.py
+++ b/backend/uclapi/roombookings/views.py
@@ -1,13 +1,12 @@
 from functools import reduce
 
-from django.http import JsonResponse
 from rest_framework.decorators import api_view
 from .models import Room, Equipment, BookingA, BookingB, Lock
 from .decorators import does_token_exist, log_api_call
 
 from .helpers import _parse_datetime, _serialize_rooms, \
     _get_paginated_bookings, _create_page_token, _return_json_bookings, \
-    _serialize_equipment
+    _serialize_equipment, PrettyJsonResponse as JsonResponse
 
 
 @api_view(['GET'])


### PR DESCRIPTION
## What does this PR do?
This PR automatically indents the `JsonResponse` object for user-friendliness. `PrettyJsonResponse` inherits from `JsonResponse` so that it still works with Django but the response looks nice.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?

## 📃 Link to PR updating documentation (if applicable)
No.

## 🚨 Is this a breaking change for API clients?
No.

## :squirrel: Deploy notes
No.

## Anything else
No.