### PR TITLE
Implementing PostgreSQL Connection Pooling with Gunicorn Support

### DIFF
--- a/backend/uclapi/.env.example
+++ b/backend/uclapi/.env.example
@@ -31,6 +31,12 @@ DB_UCLAPI_PASSWORD=
 DB_UCLAPI_HOST=
 DB_UCLAPI_PORT=5432
 
+# The size of the PostgreSQL connection pool to use for the main db
+# Set this to some value slightly smaller than max_connections divided by the
+# number of EC2 hosts provisioned to host the API, divided by the number of
+# gunicorn workers
+DB_UCLAPI_POOL_SIZE=
+
 ### Oracle Room Bookings Settings
 ## These are the Oracle access credentials for the Room Bookings database.
 
@@ -46,6 +52,12 @@ DB_CACHE_USERNAME=
 DB_CACHE_PASSWORD=
 DB_CACHE_HOST=
 DB_CACHE_PORT=5432
+
+# The size of the PostgreSQL connection pool to use for the gencache
+# Set this to some value slightly smaller than max_connections divided by the
+# number of EC2 hosts provisioned to host the API, divided by the number of
+# gunicorn workers
+DB_CACHE_POOL_SIZE=
 
 ### Oracle environment variables
 ## These variables should be set up to ensure that the instant client works.

--- a/backend/uclapi/gunicorn_config.py
+++ b/backend/uclapi/gunicorn_config.py
@@ -1,3 +1,5 @@
+from psycogreen.gevent import patch_psycopg
+
 import multiprocessing
 
 bind = "127.0.0.1:9000"
@@ -17,3 +19,7 @@ proc_name = "uclapi_gunicorn"
 
 timeout = 600
 greaceful_timeout = 600
+
+def post_fork(server, worker):
+    patch_psycopg()
+    worker.log.info("Made Psycopg2 Green")

--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -7,6 +7,7 @@ contextlib2==0.5.5
 cx-Oracle==5.3
 Django==1.11.1
 django-cors-headers==2.0.2
+django-db-geventpool==1.21
 django-dotenv==1.4.1
 djangorestframework==3.6.3
 freezegun==0.3.9

--- a/backend/uclapi/roombookings/decorators.py
+++ b/backend/uclapi/roombookings/decorators.py
@@ -2,8 +2,10 @@ from dashboard.models import App
 from django.core.exceptions import ObjectDoesNotExist
 from uclapi.settings import REDIS_UCLAPI_HOST
 from .helpers import PrettyJsonResponse as JsonResponse, how_many_seconds_until_midnight
+from uclapi.utils import strtobool
 
 import keen
+import os
 import re
 import redis
 
@@ -61,7 +63,8 @@ def log_api_call(view_func):
             "queryparams": queryparams
         }
 
-        keen.add_event("apicall", parameters)
+        if strtobool(os.environ.get("UCLAPI_PRODUCTION")):
+            keen.add_event("apicall", parameters)
 
         return view_func(request, *args, **kwargs)
     return wrapped

--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -108,12 +108,16 @@ WSGI_APPLICATION = 'uclapi.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': 'django_db_geventpool.backends.postgresql_psycopg2',
         'NAME': os.environ.get("DB_UCLAPI_NAME"),
         'USER': os.environ.get("DB_UCLAPI_USERNAME"),
         'PASSWORD': os.environ.get("DB_UCLAPI_PASSWORD"),
         'HOST': os.environ.get("DB_UCLAPI_HOST"),
-        'PORT': os.environ.get("DB_UCLAPI_PORT")
+        'PORT': os.environ.get("DB_UCLAPI_PORT"),
+        'CONN_MAX_AGE': 0,
+        'OPTIONS': {
+            'MAX_CONNS': int(os.environ.get("DB_UCLAPI_POOL_SIZE"))
+        }
     },
     'roombookings': {
         'ENGINE': 'django.db.backends.oracle',
@@ -124,12 +128,16 @@ DATABASES = {
         'PORT': ''
     },
     'gencache': {
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': 'django_db_geventpool.backends.postgresql_psycopg2',
         'NAME': os.environ.get("DB_CACHE_NAME"),
         'USER': os.environ.get("DB_CACHE_USERNAME"),
         'PASSWORD': os.environ.get("DB_CACHE_PASSWORD"),
         'HOST': os.environ.get("DB_CACHE_HOST"),
-        'PORT': os.environ.get("DB_CACHE_PORT")
+        'PORT': os.environ.get("DB_CACHE_PORT"),
+        'CONN_MAX_AGE': 0,
+        'OPTIONS': {
+            'MAX_CONNS': int(os.environ.get("DB_CACHE_POOL_SIZE"))
+        }
     }
 }
 


### PR DESCRIPTION
## What does this PR do?
It will eventually replace all connections to Postgres with a connection pool. This should hopefully stop us hitting the `max_connections` variable that is defined in pg.
This value differs depending on whether the server is a `t2.micro` or a `t2.small`, etc., so we are using environment variables to configure this.

I hope that this will make the servers more reliable under high load. At the moment, a high load can cause dropped off connections due to Postgres refusing to service them. With this implementation requests would actually get serviced; they would just be slower (as you would expect under high load).

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Just restart the API after pulling the latest code. Don't forget to install the new requirements. The new gunicorn config should get read once the restart command is triggered.

## Anything else
This is still a WIP and advice is welcomed!