### PR TITLE
Fixes error response code when no search query is supplied

### DIFF
--- a/backend/uclapi/search/views.py
+++ b/backend/uclapi/search/views.py
@@ -13,10 +13,12 @@ import requests
 @log_api_call
 def people(request):
     if "query" not in request.GET:
-        return JsonResponse({
+        response = JsonResponse({
             "ok": False,
-            "error": "No query provided"
+            "error": "No query provided."
         })
+        response.status_code = 400
+        return response
 
     query = request.GET["query"]
 


### PR DESCRIPTION
## What does this PR do?
Ensures a 400 status code is sent when no search query param is supplied to `/search/people`.

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?

## 📃 Link to PR updating documentation (if applicable)

https://github.com/uclapi/apiDocs/pulls

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes

## Anything else
This fixes #119 