### PR TITLE
restart autoupdate counter on the database from django itself

### DIFF
--- a/backend/uclapi/roombookings/management/commands/update_gencache.py
+++ b/backend/uclapi/roombookings/management/commands/update_gencache.py
@@ -2,6 +2,7 @@ import os
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.db import connections
 
 import cx_Oracle
 from roombookings.models import BookingA, BookingB, Lock
@@ -38,7 +39,10 @@ class Command(BaseCommand):
 
         self.stdout.write("Flushing the clone table...")
         # flush the table
-        curr.objects.using("gencache").all().delete()
+        cursor = connections['gencache'].cursor()
+        cursor.execute(
+            "TRUNCATE TABLE {} RESTART IDENTITY;".format(
+                    "roombookings_" + curr.__name__.lower()))
 
         self.stdout.write(
             "Dumping all the data from Oracle into a new list..."

--- a/backend/uclapi/timetable/management/commands/update_timetable_gencache.py
+++ b/backend/uclapi/timetable/management/commands/update_timetable_gencache.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.db import connections
 
 from timetable.models import \
     Timetable, TimetableA, TimetableB, \
@@ -45,7 +46,12 @@ class Command(BaseCommand):
                         map(lambda k: (k, getattr(obj, k)),
                             map(lambda l: l.name, obj._meta.get_fields())))
                 ))
-            c[tbu].objects.all().delete()
+
+            cursor = connections['gencache'].cursor()
+            cursor.execute(
+                "TRUNCATE TABLE {} RESTART IDENTITY;".format(
+                        "roombookings_" + c[tbu].__name__.lower()))
+
             c[tbu].objects.using('gencache').bulk_create(
                 new_objs,
                 batch_size=5000

--- a/backend/uclapi/timetable/management/commands/update_timetable_gencache.py
+++ b/backend/uclapi/timetable/management/commands/update_timetable_gencache.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
             cursor = connections['gencache'].cursor()
             cursor.execute(
                 "TRUNCATE TABLE {} RESTART IDENTITY;".format(
-                        "roombookings_" + c[tbu].__name__.lower()))
+                        "timetable_" + c[tbu].__name__.lower()))
 
             c[tbu].objects.using('gencache').bulk_create(
                 new_objs,


### PR DESCRIPTION
## What does this PR do?
This executes a raw query everytime buckets are refilled to ensure that the auto increment starts from 0 for the primary key ids. This also replaces the `Model.objects.all().delete()` with truncate. Using raw query should give some millisecond advantage.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [ ] Are tests done/modified?

