### PR TITLE
Change docs references to objects, dicts and maps 

### DIFF
--- a/frontend/src/react/components/documentation/Routes/Timetable/GetPersonalTimetable.jsx
+++ b/frontend/src/react/components/documentation/Routes/Timetable/GetPersonalTimetable.jsx
@@ -105,13 +105,13 @@ export default class GetPersonalTimetable extends React.Component {
             codeExamples={responseCodeExample}>
             <h2>Response</h2>
             <p>
-              The timetable field contains a map where dates are mapped to event objects.
+              The timetable field contains an object where dates are mapped to event objects.
             </p>
             <Table
               name="Response">
               <Cell
                 name="location"
-                extra="dict"
+                extra="object"
                 example="JSON Object"
                 description="Location of details of the timetable event." />
               <Cell
@@ -151,7 +151,7 @@ export default class GetPersonalTimetable extends React.Component {
                 description="End time of the event." />
               <Cell
                 name="module"
-                extra="dict"
+                extra="object"
                 example="JSON Object"
                 description="Json object containing module details." />
               <Cell

--- a/frontend/src/react/components/documentation/Routes/Timetable/GetTimetableByModules.jsx
+++ b/frontend/src/react/components/documentation/Routes/Timetable/GetTimetableByModules.jsx
@@ -126,7 +126,7 @@ export default class GetEquiment extends React.Component {
               name="Response">
               <Cell
                 name="location"
-                extra="dict"
+                extra="object"
                 example="JSON Object"
                 description="Location of details of the timetable event." />
               <Cell
@@ -166,7 +166,7 @@ export default class GetEquiment extends React.Component {
                 description="End time of the event." />
               <Cell
                 name="module"
-                extra="dict"
+                extra="object"
                 example="JSON Object"
                 description="Json object containing module details." />
               <Cell

--- a/frontend/src/react/components/documentation/Routes/Timetable/GetTimetableByModules.jsx
+++ b/frontend/src/react/components/documentation/Routes/Timetable/GetTimetableByModules.jsx
@@ -120,7 +120,7 @@ export default class GetEquiment extends React.Component {
               This endpoint will create a timetable for the module ids provided and return the yearly calendar.
             </p>
             <p>
-              The <code>timetable</code> field contains a map where dates are mapped to event objects.
+              The <code>timetable</code> field contains an object where dates are mapped to event objects.
             </p>
             <Table
               name="Response">


### PR DESCRIPTION
## What does this PR do?
The current docs refer to this JSON structure:
`{"foo": "bar"}`
as variously an object, a dict, and even a map. 

This is confusing when reading the docs, so I propose changing it to make it consistent.
Per the [JSON spec](http://json.org/), this is called an object, so I've gone with that, although I think the most important thing is that the wording is consistent. 

Would be interesting to see what you think :)

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes/No

## :squirrel: Deploy notes
For example: Need to run migrations as part of deployment

## Anything else
