### PR TITLE
Changed Search Version Header

### DIFF
--- a/frontend/src/react/components/documentation/Routes/Search/VersionHeader.jsx
+++ b/frontend/src/react/components/documentation/Routes/Search/VersionHeader.jsx
@@ -17,7 +17,7 @@ export default class VersionHeader extends React.Component {
           <Table>
             <Cell
               name="Version Header"
-              example="uclapi-roombookings-version" />
+              example="uclapi-search-version" />
             <Cell
               name="Latest Version"
               example="1" />


### PR DESCRIPTION
## What does this PR do?
Fixes documentation for the Search Endpoint by using an appropriate version header instead of the `roombookings` version header.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [X] Are tests done/modified?
- [X] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Just the usual, I guess? 🤷‍♂️ 

## Anything else
Even though the source file had the correct documentation, the Search docs showed the info from the room booking docs due to using an incorrect tag, I changed that tag to a new, `uclapi-search-version` header that seems to be consistent with the naming scheme. Maintainers, please tell me if there are any other links I'd have to change to actually create a new version header for the search docs.

What it is showing right now: 
![screenshot-2017-11-24 ucl api docs](https://user-images.githubusercontent.com/8849915/33225424-25e4c434-d16f-11e7-91d9-b9e856bf0ca5.png)

