### PR TITLE
Cadcap live images

### DIFF
--- a/backend/uclapi/.env.example
+++ b/backend/uclapi/.env.example
@@ -102,3 +102,9 @@ AWS_S3_BUCKET_PATH=/
 AWS_S3_REGION=eu-west-2
 AWS_ACCESS_KEY_ID=
 AWS_ACCESS_SECRET=
+
+# Do not let eventlet monkey patch the socket libraries
+# This property should be False / non-existent in prod
+# In staging it must be set to True, or manage.py runserver
+# will be broken.
+EVENTLET_NOPATCH=True

--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -9,7 +9,7 @@ ciso8601==1.0.7
 cx-Oracle==6.2
 decorator==4.2.1
 deepdiff==3.3.0
-Django==1.11.7
+Django==1.11.11
 django-cors-headers==2.2.0
 django-dotenv==1.4.2
 django-mock-queries==1.0.7

--- a/backend/uclapi/uclapi/wsgi.py
+++ b/backend/uclapi/uclapi/wsgi.py
@@ -22,6 +22,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "uclapi.settings")
 
 # Patch the socket libraries to work properly
 # This is crucial for multiprocessing to work
-eventlet.monkey_patch()
+# We only do this if the environment variable
+# to not patch doesn't exist.
+# This is because the patch breaks runserver.
+if os.environ.get("EVENTLET_NOPATCH") != 'True':
+    eventlet.monkey_patch()
 
 application = get_wsgi_application()

--- a/backend/uclapi/workspaces/image_builder.py
+++ b/backend/uclapi/workspaces/image_builder.py
@@ -1,0 +1,94 @@
+import redis
+
+from lxml import etree
+from django.conf import settings
+
+from .occupeye import OccupEyeApi, BadOccupEyeRequest
+
+class ImageBuilder():
+    """
+    Builds an SVG image with live sensor statuses/
+    """
+    def __init__(self, survey_id, map_id):
+        # Confirm integers
+        if not survey_id.isdigit():
+            raise BadOccupEyeRequest
+        if not map_id.isdigit():
+            raise BadOccupEyeRequest
+
+        self._api = OccupEyeApi()
+        self._redis = redis.StrictRedis(
+            host=settings.REDIS_UCLAPI_HOST,
+            charset="utf-8",
+            decode_responses=True
+        )
+        self._sensors = self._api.get_survey_sensors(
+            survey_id,
+            return_states=True
+        )
+        self._survey_id = survey_id
+        self._map_id = map_id
+        self._absent_colour = "#ABE00C"
+        self._occupied_colour = "#FFC90E"
+
+
+    def set_colours(self, absent="#ABE00C", occupied="#FFC90E"):
+        self._absent_colour = absent
+        self._occupied_colour = occupied
+
+
+    def get_live_map(self):
+        map_data = self._api.get_survey_image_map_data(
+            self._survey_id,
+            self._map_id
+        )
+        nsmap = {
+            None: "http://www.w3.org/2000/svg",
+            "xlink": "http://www.w3.org/1999/xlink",
+            "ev": "http://www.w3.org/2001/xml-events"
+        }
+        svg = etree.Element(
+            "svg",
+            nsmap=nsmap
+        )
+        viewport = etree.SubElement(svg, "g")
+        viewport.attrib["transform"] = "scale(0.02, 0.02)"
+        base_map = etree.SubElement(viewport, "image")
+        base_map.attrib["width"] = map_data["VMaxX"]
+        base_map.attrib["height"] = map_data["VMaxY"]
+        map_data = self._redis.hgetall(
+            "occupeye:surveys:{}:maps:{}".format(
+                self._survey_id,
+                self._map_id
+            )
+        )
+        (b64_data, content_type) = self._api.get_image(
+            map_data["image_id"]
+        )
+        base_map.attrib["{http://www.w3.org/1999/xlink}href"] = "data:{};base64,{}".format(
+            content_type,
+            b64_data
+        )
+        bubble_overlay = etree.SubElement(viewport, "g")
+
+        # Get the sensors for that map
+        the_map = {}
+        for map_obj in self._sensors["maps"]:
+            if map_obj["id"] == self._map_id:
+                the_map = map_obj
+                break
+
+        for sensor_id, sensor_data in the_map["sensors"].items():
+            node = etree.SubElement(viewport, "g")
+            node.attrib["transform"] = "translate({},{})".format(
+                sensor_data["x_pos"],
+                sensor_data["y_pos"]
+            )
+            circle = etree.SubElement(node, "circle")
+            circle.attrib["r"] = "128"
+            if sensor_data["last_trigger_type"] == "Absent":
+                circle.attrib["fill"] = self._absent_colour
+            else:
+                circle.attrib["fill"] = self._occupied_colour
+
+        return etree.tostring(svg, pretty_print=True)

--- a/backend/uclapi/workspaces/image_builder.py
+++ b/backend/uclapi/workspaces/image_builder.py
@@ -36,12 +36,21 @@ class ImageBuilder():
         )
         self._survey_id = survey_id
         self._map_id = map_id
-        self._absent_colour = "#ABE00C"
-        self._occupied_colour = "#FFC90E"
+
+        # Set the defaults
+        self.set_colours()
+        self.set_image_scale()
+        self.set_circle_radius()
 
     def set_colours(self, absent="#ABE00C", occupied="#FFC90E"):
         self._absent_colour = absent
         self._occupied_colour = occupied
+
+    def set_image_scale(self, image_scale=0.02):
+        self._image_scale = image_scale
+
+    def set_circle_radius(self, circle_radius=128):
+        self._circle_radius = circle_radius
 
     def get_live_map(self):
         map_data = self._api.get_survey_image_map_data(
@@ -58,7 +67,11 @@ class ImageBuilder():
             nsmap=nsmap
         )
         viewport = etree.SubElement(svg, "g")
-        viewport.attrib["transform"] = "scale(0.02, 0.02)"
+        scale = "scale({}, {})".format(
+            self._image_scale,
+            self._image_scale
+        )
+        viewport.attrib["transform"] = scale
         base_map = etree.SubElement(viewport, "image")
         base_map.attrib["width"] = map_data["VMaxX"]
         base_map.attrib["height"] = map_data["VMaxY"]
@@ -93,7 +106,7 @@ class ImageBuilder():
                 sensor_data["y_pos"]
             )
             circle = etree.SubElement(node, "circle")
-            circle.attrib["r"] = "128"
+            circle.attrib["r"] = str(self._circle_radius)
             if sensor_data["last_trigger_type"] == "Absent":
                 circle.attrib["fill"] = self._absent_colour
             else:

--- a/backend/uclapi/workspaces/occupeye.py
+++ b/backend/uclapi/workspaces/occupeye.py
@@ -958,6 +958,16 @@ class OccupEyeApi():
 
         return data
 
+    def check_survey_exists(self, survey_id):
+        survey_data_key = "occupeye:surveys:{}".format(survey_id)
+        return self._redis.exists(survey_data_key)
+
+    def check_map_exists(self, survey_id, map_id):
+        map_data_key = "occupeye:surveys:{}:maps:{}".format(
+            survey_id,
+            map_id
+        )
+        return self._redis.exists(map_data_key)
 
     def feed_cache(self):
         """

--- a/backend/uclapi/workspaces/occupeye.py
+++ b/backend/uclapi/workspaces/occupeye.py
@@ -954,7 +954,7 @@ class OccupEyeApi():
             "VMaxX": map_vmax_x,
             "VMaxY": map_vmax_y,
             "ViewBox": map_viewbox
-        }  
+        }
 
         return data
 

--- a/backend/uclapi/workspaces/urls.py
+++ b/backend/uclapi/workspaces/urls.py
@@ -4,7 +4,8 @@ from . import views
 
 urlpatterns = [
      url(r'^surveys$', views.get_surveys),
-     url(r'^image$', views.get_image),
+     url(r'^images/map/live$', views.get_live_map),
+     url(r'^images/map$', views.get_map_image),
      url(r'^sensors/lastupdated$', views.get_survey_max_timestamp),
      url(r'^sensors/summary$', views.get_survey_sensors_summary),
      url(r'^sensors/averages/time$', views.get_historical_time_data),

--- a/backend/uclapi/workspaces/views.py
+++ b/backend/uclapi/workspaces/views.py
@@ -282,7 +282,7 @@ def get_live_map(request, *args, **kwargs):
 
     if not re.match(colour_pattern, absent_colour) or \
        not re.match(colour_pattern, occupied_colour):
-        response = sonResponse({
+        response = JsonResponse({
             "ok": False,
             "error": (
                 "The custom colours you specfied did not match "

--- a/backend/uclapi/workspaces/views.py
+++ b/backend/uclapi/workspaces/views.py
@@ -6,7 +6,6 @@ from common.decorators import uclapi_protected_endpoint
 from common.helpers import PrettyJsonResponse as JsonResponse
 from common.helpers import RateLimitHttpResponse as HttpResponse
 
-from django.http import HttpResponse
 from rest_framework.decorators import api_view
 
 from .occupeye import BadOccupEyeRequest, OccupEyeApi
@@ -312,7 +311,8 @@ def get_live_map(request, *args, **kwargs):
 
     response = HttpResponse(
         map_svg,
-        content_type="image/svg+xml"
+        content_type="image/svg+xml",
+        rate_limiting_data=kwargs
     )
     response["Content-Length"] = len(map_svg)
 

--- a/frontend/src/react/components/documentation/Documentation.jsx
+++ b/frontend/src/react/components/documentation/Documentation.jsx
@@ -33,6 +33,7 @@ import WorkspacesGetLastSensorUpdate from './Routes/Workspaces/GetLastSensorUpda
 import WorkspacesGetHistoricalTimeData from './Routes/Workspaces/GetSensorHistoricalTimeData.jsx';
 import WorkspaceGetSensorsSummary from './Routes/Workspaces/GetSensorSummary.jsx';
 import WorkspacesGetImage from './Routes/Workspaces/GetImage.jsx';
+import WorkspacesGetLiveImage from './Routes/Workspaces/GetLiveImage.jsx';
 
 import GetInvolved from './GetInvolved/GetInvolved.jsx';
 
@@ -84,6 +85,7 @@ export default class DocumentationComponent extends React.Component {
             <WorkspacesGetLastSensorUpdate />
             <WorkspaceGetSensorsSummary />
             <WorkspacesGetImage />
+            <WorkspacesGetLiveImage />
 
             <GetInvolved />
           </LanguageTabs>

--- a/frontend/src/react/components/documentation/Routes/Workspaces/GetImage.jsx
+++ b/frontend/src/react/components/documentation/Routes/Workspaces/GetImage.jsx
@@ -13,15 +13,15 @@ params = {
   "image_format": "base64"
 }
 
-r = requests.get("https://uclapi.com/workspaces/image", params=params)
+r = requests.get("https://uclapi.com/workspaces/images/map", params=params)
 print(r.json())`,
 
-  shell: `curl -X GET https://uclapi.com/workspaces/image \
+  shell: `curl -X GET https://uclapi.com/workspaces/images/map \
 -d token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb \
 -d image_id=79
 -d image_format=base64`,
 
-  javascript: `fetch("https://uclapi.com/workspaces/image?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&image_id=46&image_format=base64",
+  javascript: `fetch("https://uclapi.com/workspaces/images/map?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&image_id=46&image_format=base64",
 {
     method: "GET",
 })
@@ -52,9 +52,9 @@ export default class WorkspacesGetImage extends React.Component {
                 <Topic
                     activeLanguage={this.props.activeLanguage}
                     codeExamples={codeExamples}>
-                    <h1 id="workspaces/image">Get a Map's Image</h1>
+                    <h1 id="workspaces/images/map">Get a Map's Image</h1>
                     <p>
-                        Endpoint: <code>https://uclapi.com/workspaces/image</code>
+                        Endpoint: <code>https://uclapi.com/workspaces/images/map</code>
                     </p>
                     <p>
                         This endpoint gets the image specified by the passed in image_id. Image IDs are provided by the <code>/workspaces/surveys</code> endpoint within the array of maps. Each map has an image.

--- a/frontend/src/react/components/documentation/Routes/Workspaces/GetLiveImage.jsx
+++ b/frontend/src/react/components/documentation/Routes/Workspaces/GetLiveImage.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+import Topic from './../../Topic.jsx';
+import Table from './../../Table.jsx';
+import Cell from './../../Cell.jsx';
+
+let codeExamples = {
+    python: `import requests
+
+params = {
+  "token": "uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb",
+  "survey_id": "22",
+  "map_id": "3"
+}
+
+r = requests.get("https://uclapi.com/workspaces/images/map/live", params=params)
+print(r.json())`,
+
+  shell: `curl -X GET https://uclapi.com/workspaces/images/map/live \
+-d token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb \
+-d survey_id=22
+-d map_id=3`,
+
+  javascript: `fetch("https://uclapi.com/workspaces/images/map/live?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&survey_id=22&map_id=3",
+{
+    method: "GET",
+})
+.then((response) => {
+  return response.json()
+})
+.then((json) => {
+  console.log(json);
+})`
+}
+
+let response = `
+<svg xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+    <g transform="scale(0.02, 0.02)">
+        <image width="28329.0" height="29882.0" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA7QAAA..."/>
+        <g>
+            <g transform=""translate(13223.0,27477.0)">
+                <circle r="128" fill="#FFC90E"/>
+            </g>
+            <g transform="translate(13223.0,26708.0)">
+                <circle r="128" fill="#FFC90E"/>
+            </g>
+            ...
+        </g>
+    </g>
+</svg>
+`
+
+let responseCodeExample = {
+    python: response,
+    javascript: response,
+    shell: response
+}
+
+export default class WorkspacesGetLiveImage extends React.Component {
+    render() {
+        return (
+            <div>
+                <Topic
+                    activeLanguage={this.props.activeLanguage}
+                    codeExamples={codeExamples}>
+                    <h1 id="workspaces/images/map/live">Get a Map's Image with Seat States Shown</h1>
+                    <p>
+                        Endpoint: <code>https://uclapi.com/workspaces/images/map/live</code>
+                    </p>
+                    <p>
+                        This endpoint takes Survey ID and Map ID as parameters and displays a dynamically generated SVG map, correct as of the time of the API call (aside from caching overhead), showing the map's plan image with a circle overlaid on each seat. This circle is coloured based on whether the seat is occupied or absent (e.g. it's free).
+                    </p>
+                    <p>
+                        There are also several parameters that let you customise the map to suit your app or integration.
+                    </p>
+
+                    <Table
+                        name="Query Parameters">
+                        <Cell
+                            name="token"
+                            requirement="required"
+                            example="uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb"
+                            description="Authentication token." />
+                        <Cell
+                            name="survey_id"
+                            requirement="required"
+                            example="22"
+                            description="The ID of the library's survey which contains the map you want to obtain." />
+                        <Cell
+                            name="map_id"
+                            requirement="required"
+                            example="3"
+                            description="The ID of the library's survey which contains the map you want to obtain." />
+                        <Cell
+                            name="image_scale"
+                            requirement="optional"
+                            example="0.02"
+                            description="The SVG image's scale. The default is 0.02. The scale is implemented as an SVG transform scale, and is applied to both the x and the y axes of the image." />
+                        <Cell
+                            name="circle_radius"
+                            requirement="optional"
+                            example="128"
+                            description="The size of the circle. This must be a positive float value. The default is 128." />
+                        <Cell
+                            name="absent_colour"
+                            requirement="optional"
+                            example="#ABE00C"
+                            description="The colour of the circle designating a free seat. This must be provided as a hex colour code, including the preceeding # symbol. The default is #ABE00C." />
+                        <Cell
+                            name="occupied_colour"
+                            requirement="optional"
+                            example="#FFC90E"
+                            description="The colour of the circle designating a taken, or occupied, seat. This must be provided as a hex colour code, including the preceeding # symbol. The default is #FFC90E." />                        
+                    </Table>
+                </Topic>
+
+                <Topic
+                    activeLanguage={this.props.activeLanguage}
+                    codeExamples={responseCodeExample}>
+                    <h2>Response</h2>
+                    <p>
+                        The response will be XML SVG data that contains a base64-encoded PNG map (the same data that is returned by `/workspaces/images/map`) and vector circles designating which seats are free and occupied. An example of this returned data is on the right.
+                    </p>
+                </Topic>
+            </div>
+        )
+    }
+}

--- a/frontend/src/react/components/documentation/Sidebar.jsx
+++ b/frontend/src/react/components/documentation/Sidebar.jsx
@@ -189,7 +189,11 @@ export default class Sidebar extends React.Component {
               />,
               <ListItem
                 primaryText="Get Map Image"
-                href="#workspaces/image"
+                href="#workspaces/images/map"
+              />,
+              <ListItem
+                primaryText="Get Live Map Image"
+                href="#workspaces/images/map/live"
               />
             ]}
           />


### PR DESCRIPTION
## What does this PR do?
- Django Update
- Fixes the `runserver` issue
- Most importantly, adds SVG image generation to show every seat, live, on its map!

## ✅ Pull Request checklist

- [x] Is this code complete?
- [ ] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes
I have changed the image endpoint (but this hasn't been used yet so I'm not concerned)

## :squirrel: Deploy notes
Re-run OccupEye cache

## Anything else
