### PR TITLE
Adds student number scope to OAuth

### DIFF
--- a/backend/uclapi/oauth/scoping.py
+++ b/backend/uclapi/oauth/scoping.py
@@ -18,6 +18,7 @@
 class Scopes:
     SCOPE_MAP = {
         "timetable": (1, "Personal Timetable"),
+        "student_number": (2, "Student Number"),
     }
 
     def __init__(self, scope_map=None):

--- a/backend/uclapi/oauth/urls.py
+++ b/backend/uclapi/oauth/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     url(r'tokens/test$', views.token_test),
     url(r'user/allow$', views.userallow),
     url(r'user/deny$', views.userdeny),
-    url(r'user/data$', views.userdata)
+    url(r'user/data$', views.userdata),
+    url(r'user/studentnumber$', views.get_student_number),
 ]

--- a/backend/uclapi/timetable/app_helpers.py
+++ b/backend/uclapi/timetable/app_helpers.py
@@ -38,7 +38,7 @@ _rooms_cache = {}
 _department_name_cache = {}
 
 
-def _get_cache(model_name):
+def get_cache(model_name):
     """Returns the cache bucket for the requested model name"""
     timetable_models = {
         "module": [ModuleA, ModuleB],
@@ -72,9 +72,9 @@ def _get_cache(model_name):
     return model
 
 
-def _get_student_by_upi(upi):
+def get_student_by_upi(upi):
     """Returns a StudentA or StudentB object by UPI"""
-    students = _get_cache("students")
+    students = get_cache("students")
     # Assume the current Set ID due to caching
     upi_upper = upi.upper()
     student = students.objects.filter(
@@ -98,7 +98,7 @@ def _get_full_department_name(department_code):
     if department_code in _department_name_cache:
         return _department_name_cache[department_code]
     else:
-        departments = _get_cache("departments")
+        departments = get_cache("departments")
         try:
             dept = departments.objects.get(deptid=department_code)
             _department_name_cache[department_code] = dept.name
@@ -109,7 +109,7 @@ def _get_full_department_name(department_code):
 
 def _get_lecturer_details(lecturer_upi):
     """Returns a lecturer's name and email address from their UPI"""
-    lecturers = _get_cache("lecturer")
+    lecturers = get_cache("lecturer")
     details = {
         "name": "Unknown",
         "email": "Unknown",
@@ -140,10 +140,10 @@ def _get_timetable_events(full_modules, stumodules):
     if not _week_map:
         _map_weeks()
 
-    timetable = _get_cache("timetable")
-    modules = _get_cache("module")
+    timetable = get_cache("timetable")
+    modules = get_cache("module")
 
-    bookings = _get_cache("booking")
+    bookings = get_cache("booking")
 
     full_timetable = {}
     for module in full_modules:
@@ -277,7 +277,7 @@ def _get_timetable_events_module_list(module_list):
     if not _week_map:
         _map_weeks()
 
-    modules = _get_cache("module")
+    modules = get_cache("module")
 
     full_modules = []
 
@@ -291,8 +291,8 @@ def _get_timetable_events_module_list(module_list):
 
 
 def _map_weeks():
-    weekmapnumeric = _get_cache("weekmapnumeric")
-    weekstructure = _get_cache("weekstructure")
+    weekmapnumeric = get_cache("weekmapnumeric")
+    weekstructure = get_cache("weekstructure")
     week_nums = weekmapnumeric.objects.all()
     week_strs = weekstructure.objects.all()
 
@@ -353,8 +353,8 @@ def _get_location_details(siteid, roomid):
 
     cache_id = siteid + "___" + roomid
     if cache_id not in _rooms_cache:
-        rooms = _get_cache("rooms")
-        sites = _get_cache("sites")
+        rooms = get_cache("rooms")
+        sites = get_cache("sites")
         try:
             room = rooms.objects.filter(roomid=roomid, siteid=siteid)[0]
             site = sites.objects.filter(siteid=siteid)[0]
@@ -392,7 +392,7 @@ def get_student_timetable(upi, date_filter=None):
         data = r.get(timetable_key)
         student_events = json.loads(data)
     else:
-        student = _get_student_by_upi(upi)
+        student = get_student_by_upi(upi)
         student_modules = _get_student_modules(student)
         student_events = _get_timetable_events(student_modules, True)
         # Celery task to cache for the next request

--- a/frontend/src/react/components/documentation/Documentation.jsx
+++ b/frontend/src/react/components/documentation/Documentation.jsx
@@ -9,6 +9,7 @@ import OAuthIntro from './Routes/OAuth/OAuthIntro.jsx';
 import Authorise from './Routes/OAuth/Authorise.jsx';
 import Token from './Routes/OAuth/Token.jsx';
 import UserData from './Routes/OAuth/UserData.jsx';
+import StudentNumber from './Routes/OAuth/StudentNumber.jsx';
 
 import RoomBookingsVersionHeader from './Routes/RoomBookings/VersionHeader.jsx';
 import GetRooms from './Routes/RoomBookings/GetRooms.jsx';
@@ -56,6 +57,7 @@ export default class DocumentationComponent extends React.Component {
             <Authorise />
             <Token />
             <UserData />
+            <StudentNumber />
 
             <SectionHeader link="roombookings" title="Room Bookings" />
             <RoomBookingsVersionHeader />

--- a/frontend/src/react/components/documentation/Routes/OAuth/StudentNumber.jsx
+++ b/frontend/src/react/components/documentation/Routes/OAuth/StudentNumber.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+
+import Topic from './../../Topic.jsx';
+import Table from './../../Table.jsx';
+import Cell from './../../Cell.jsx';
+
+
+let codeExamples = {
+  python: `import requests
+
+params = {
+  "token": "uclapi-user-abd-def-ghi-jkl",
+  "client_secret": "secret",
+}
+r = requests.get("https://uclapi.com/oauth/user/studentnumber", params=params)
+print(r.json())`,
+
+  shell: `curl https://uclapi.com/oauth/user/studentnumber?client_secret=secret&token=uclapi-user-abd-def-ghi-jkl`,
+
+  javascript: `fetch("https://uclapi.com/oauth/user/studentnumber?client_secret=secret&token=uclapi-user-abd-def-ghi-jkl")
+.then((response) => {
+  return response.json()
+})
+.then((json) => {
+  console.log(json);
+})`
+}
+
+let response = `{
+    "ok": true,
+    "student_number": "123456789"
+}`
+
+let responseCodeExample = {
+  python: response,
+  javascript: response,
+  shell: response
+}
+
+
+export default class StudentNumber extends React.Component {
+
+    render () {
+      return (
+        <div>
+          <Topic
+            activeLanguage={this.props.activeLanguage}
+            codeExamples={codeExamples}>
+            <h1 id="oauth/user/studentnumber">Student Number</h1>
+            <p>
+              Endpoint: <code>https://uclapi.com/oauth/user/studentnumber</code>
+            </p>
+            <p>
+              You can use the `oauth/user/data` endpoint to find out whether the user is a student before you call this endpoint. If you call this endpoint and the user is not a student, an error will be returned.
+            </p>
+            <p>
+              Please note: to use this endpoint you must have ticked the <em>Student Number</em> scope for your application in the UCL API Dashboard. This piece of information has been separated from the others because a student number can in some cases be considered confidential. This is because any data exported directly from Portico, SITS (E:Vision) or CMIS is usually grouped by Student Number. One example is that in some cases departments choose to release spreadsheets of examination results where each student is identified by their student number, and not their name, to provide a degree of anonymity in what is otherwise an open data set. You should consider carefully whether you actually need a student number to track students when other unique identifiers are available, such as their username-based email address and UPI. If you request a student number and it is not required for your application, your users may choose not to provide this information to you, and therefore deny your application permission to access their details.
+            </p>
+
+            <Table
+              name="Query Parameters">
+              <Cell
+                name="token"
+                requirement="required"
+                example="uclapi-user-abd-def-ghi-jkl"
+                description="OAuth user token." />
+              <Cell
+                name="client_id"
+                requirement="required"
+                example="123.456"
+                description="Client ID of the authenticating app." />
+            </Table>
+          </Topic>
+
+          <Topic
+            activeLanguage={this.props.activeLanguage}
+            codeExamples={responseCodeExample}>
+            <h2>Response</h2>
+            <Table
+              name="Response">
+            <Cell
+              name="student_number"
+              extra="string"
+              example="123456789"
+              description="The user's student number. This may be prefixed with a 0 so should be treated as a string, even though it is made up only of digits. The maximum possible length is 12 digits." />
+            </Table>
+          </Topic>
+
+          <Topic
+            noExamples={true}>
+            <Table
+              name="Errors">
+              <Cell
+                name="Token does not exist."
+                description="Gets returned when token does not exist." />
+              <Cell
+                name="Client secret incorrect."
+                description="Gets returned when the client secret was incorrect." />
+              <Cell
+                name="User is not a student."
+                description="The user is not a student, and therefore has no student number that can be returned." />
+            </Table>
+          </Topic>
+        </div>
+      )
+    }
+
+}

--- a/frontend/src/react/components/documentation/Routes/OAuth/StudentNumber.jsx
+++ b/frontend/src/react/components/documentation/Routes/OAuth/StudentNumber.jsx
@@ -51,7 +51,7 @@ export default class StudentNumber extends React.Component {
               Endpoint: <code>https://uclapi.com/oauth/user/studentnumber</code>
             </p>
             <p>
-              You can use the `oauth/user/data` endpoint to find out whether the user is a student before you call this endpoint. If you call this endpoint and the user is not a student, an error will be returned.
+              You can use the <code>oauth/user/data</code> endpoint to find out whether the user is a student before you call this endpoint. If you call this endpoint and the user is not a student, an error will be returned.
             </p>
             <p>
               Please note: to use this endpoint you must have ticked the <em>Student Number</em> scope for your application in the UCL API Dashboard. This piece of information has been separated from the others because a student number can in some cases be considered confidential. This is because any data exported directly from Portico, SITS (E:Vision) or CMIS is usually grouped by Student Number. One example is that in some cases departments choose to release spreadsheets of examination results where each student is identified by their student number, and not their name, to provide a degree of anonymity in what is otherwise an open data set. You should consider carefully whether you actually need a student number to track students when other unique identifiers are available, such as their username-based email address and UPI. If you request a student number and it is not required for your application, your users may choose not to provide this information to you, and therefore deny your application permission to access their details.

--- a/frontend/src/react/components/documentation/Routes/OAuth/UserData.jsx
+++ b/frontend/src/react/components/documentation/Routes/OAuth/UserData.jsx
@@ -12,7 +12,7 @@ params = {
   "token": "uclapi-user-abd-def-ghi-jkl",
   "client_secret": "secret",
 }
-r = requests.get("https://uclapi.com/oauth/token", params=params)
+r = requests.get("https://uclapi.com/oauth/user/data", params=params)
 print(r.json())`,
 
   shell: `curl https://uclapi.com/oauth/user/data?client_secret=secret&token=uclapi-user-abd-def-ghi-jkl`,
@@ -35,6 +35,7 @@ let response = `{
     "given_name": "Full",
     "upi": "fname12",
     "scope_number": 0,
+    "is_student": true
 }`
 
 let responseCodeExample = {
@@ -123,6 +124,11 @@ export default class UserData extends React.Component {
               extra="int"
               example="0"
               description="Scopes the application has access to on behalf of the user." />
+            <Cell
+              name="is_student"
+              extra="boolean"
+              example="true"
+              description="Whether the user is a student in this academic year." />
             </Table>
           </Topic>
 

--- a/frontend/src/react/components/documentation/Sidebar.jsx
+++ b/frontend/src/react/components/documentation/Sidebar.jsx
@@ -91,6 +91,10 @@ export default class Sidebar extends React.Component {
                 primaryText="User Data"
                 href="#oauth/user/data"
               />,
+              <ListItem
+                primaryText="Student Number"
+                href="#oauth/user/studentnumber"
+              />
             ]}
           />
 


### PR DESCRIPTION
## What does this PR do?
There has been a request from a student to be able to get a student's ID via OAuth. I've added this as a separate scope. The `oauth/user/data` endpoint will also tell the caller whether the user is a student or not.

Also done some fixes here and there to the OAuth code.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Just pull and restart uclapi

## Anything else
