### PR TITLE
added client_secret as required query parameter to Timetable API calls

### DIFF
--- a/frontend/src/components/documentation/Routes/Timetable/GetDataDepartments.jsx
+++ b/frontend/src/components/documentation/Routes/Timetable/GetDataDepartments.jsx
@@ -9,15 +9,17 @@ let codeExamples = {
   python: `import requests
 
 params = {
-  "token": "uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb"
+  "token": "uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb",
+  "client_secret": "secret"
 }
 r = requests.get("https://uclapi.com/timetable/data/departments", params=params)
 print(r.json())`,
 
   shell: `curl -X GET https://uclapi.com/timetable/data/departments \
--d token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb`,
+-d token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb \
+-d client_secret=secret`,
 
-  javascript: `fetch("https://uclapi.com/timetable/data/departments?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb")
+  javascript: `fetch("https://uclapi.com/timetable/data/departments?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&client_secret=secret")
 .then((response) => {
   return response.json()
 })
@@ -74,6 +76,11 @@ export default class GetDataDepartments extends React.Component {
                 requirement="required"
                 example="uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb"
                 description="Authentication token." />
+              <Cell
+                name="client_secret"
+                requirement="required"
+                example="mysecret"
+                description="Client secret of the authenticating app." />
             </Table>
           </Topic>
 
@@ -114,6 +121,12 @@ export default class GetDataDepartments extends React.Component {
               <Cell
                 name="OAuth token does not exist."
                 description="Gets returned when you supply an invalid token." />
+              <Cell
+                name="No Client Secret Provided."
+                description="Gets returned when you have not supplied a client_secret in your request." />
+              <Cell
+                name="Client Secret incorrect."
+                description="Gets returned when the client secret was incorrect." />
             </Table>
           </Topic>
         </div>

--- a/frontend/src/components/documentation/Routes/Timetable/GetDataModules.jsx
+++ b/frontend/src/components/documentation/Routes/Timetable/GetDataModules.jsx
@@ -10,6 +10,7 @@ let codeExamples = {
 
 params = {
   "token": "uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb",
+  "client_secret": "secret",
   "department": "COMPS_ENG"
 }
 r = requests.get("https://uclapi.com/timetable/data/modules", params=params)
@@ -17,9 +18,10 @@ print(r.json())`,
 
   shell: `curl -X GET https://uclapi.com/timetable/data/modules \
 -d token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb \
+-d client_secret=secret \
 -d department=COMPS_ENG`,
 
-  javascript: `fetch("https://uclapi.com/timetable/data/modules?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&department=COMPS_ENG")
+  javascript: `fetch("https://uclapi.com/timetable/data/modules?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&client_secret=secret&department=COMPS_ENG")
 .then((response) => {
   return response.json()
 })
@@ -127,11 +129,16 @@ export default class GetDataModules extends React.Component {
                 requirement="required"
                 example="uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb"
                 description="Authentication token." />
-            <Cell
-                name="department"
-                requirement="required"
-                example="COMPS_ENG"
-                description="The department ID available from /data/departments." />
+              <Cell
+              name="client_secret"
+              requirement="required"
+              example="mysecret"
+              description="Client secret of the authenticating app." />
+              <Cell
+                  name="department"
+                  requirement="required"
+                  example="COMPS_ENG"
+                  description="The department ID available from /data/departments." />
             </Table>
           </Topic>
 
@@ -273,6 +280,12 @@ export default class GetDataModules extends React.Component {
               <Cell
                 name="OAuth token does not exist."
                 description="Gets returned when you supply an invalid token." />
+              <Cell
+                name="No Client Secret Provided."
+                description="Gets returned when you have not supplied a client_secret in your request." />
+              <Cell
+                name="Client Secret incorrect."
+                description="Gets returned when the client secret was incorrect." />
             </Table>
           </Topic>
         </div>

--- a/frontend/src/components/documentation/Routes/Timetable/GetPersonalTimetable.jsx
+++ b/frontend/src/components/documentation/Routes/Timetable/GetPersonalTimetable.jsx
@@ -230,6 +230,12 @@ export default class GetPersonalTimetable extends React.Component {
               <Cell
                 name="Student does not have any assigned timetables."
                 description="Gets returned when the user the token belongs to does not have any timetable assigned." />
+              <Cell
+                name="No Client Secret Provided."
+                description="Gets returned when you have not supplied a client_secret in your request." />
+              <Cell
+                name="Client Secret incorrect."
+                description="Gets returned when the client secret was incorrect." />
             </Table>
           </Topic>
         </div>

--- a/frontend/src/components/documentation/Routes/Timetable/GetTimetableByModules.jsx
+++ b/frontend/src/components/documentation/Routes/Timetable/GetTimetableByModules.jsx
@@ -10,7 +10,8 @@ let codeExamples = {
 
 params = {
   "token": "uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb",
-  "modules": "COMP0030,COMP0133-A7U-T1"
+  "client_secret": "secret",
+  "modules": "COMP0030,COMP0133-A7U-T1"  
 }
 
 r = requests.get("https://uclapi.com/timetable/bymodule", params=params)
@@ -18,9 +19,10 @@ print(r.json())`,
 
   shell: `curl -X GET https://uclapi.com/timetable/bymodule \
 -d token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb \
+-d client_secret=secret \
 -d modules=COMP0030,COMP0133-A7U-T1`,
 
-  javascript: `fetch("https://uclapi.com/timetable/bymodule?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&modules=COMP0030,COMP0133-A7U-T1",
+  javascript: `fetch("https://uclapi.com/timetable/bymodule?token=uclapi-5d58c3c4e6bf9c-c2910ad3b6e054-7ef60f44f1c14f-a05147bfd17fdb&client_secret=secret&modules=COMP0030,COMP0133-A7U-T1",
 {
     method: "GET",
 })
@@ -355,6 +357,12 @@ export default class GetEquiment extends React.Component {
               <Cell
                 name="No module ids provided."
                 description="No module ids provided in post request." />
+              <Cell
+                name="No Client Secret Provided."
+                description="Gets returned when you have not supplied a client_secret in your request." />
+              <Cell
+                name="Client Secret incorrect."
+                description="Gets returned when the client secret was incorrect." />
             </Table>
           </Topic>
         </div>


### PR DESCRIPTION
## What does this PR do?
Current documentation did not include client_secret as a required query parameter for Timetable API calls. Hence I added that, updated the example code and also added the error responses if client_secret is not provided or is incorrect.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes


## Anything else
