### PR TITLE
Add hiredis as requirment

### DIFF
--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -22,6 +22,7 @@ freezegun==0.3.11
 greenlet==0.4.15
 grequests==0.3.0
 gunicorn==19.9.0
+hiredis==1.0.0
 idna==2.8
 jmespath==0.9.3
 jsonpickle==1.0


### PR DESCRIPTION
## What does this PR do?
Adds Hi-redis as a requirment, thus allowing redis-py to use it by default.

## ✅ Pull Request checklist

- [Yes] Is this code complete?
- [Yes] Are tests done/modified?
- [N/A] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
For example: Need to run migrations as part of deployment
N/a
## Anything else
Closes #884 