### PR TITLE
Sets default AWS bucket access policy to public-read for statics

### DIFF
--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -245,6 +245,13 @@ if strtobool(os.environ.get("AWS_S3_STATICS", "False")):
         AWS_STORAGE_BUCKET_NAME
     )
 
+    # We set the default ACL data on all stacks we upload to public-read
+    # so that the files are world readable.
+    # This is required for the statics to be served up directly.
+    # Often this is a security risk, but in this case it's
+    # actually required to serve the website.
+    AWS_DEFAULT_ACL = "public-read"
+
     # If credentials are enabled, collectstatic can do uploads
     if strtobool(os.environ["AWS_S3_STATICS_CREDENTIALS_ENABLED"]):
         AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]


### PR DESCRIPTION
## What does this PR do?
Ensures that our AWS statics are made publicly readable as per the change in `django-storages` [here](https://github.com/jschneier/django-storages/issues/381).

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Ensure in line with master when deploying statics from dev.

## Anything else
