### PR TITLE
Fix for webpack-stats.json deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ before_script:
   # Install cx_Oracle (which depends on Oracle IC)
   - cd ./../backend/uclapi
   - pip3 install $(cat requirements.txt | grep "cx-Oracle")
-  - cp webpack-stats.sample.json dashboard/static/webpack-stats.json
+  - mkdir static
+  - cp webpack-stats.sample.json ./static/webpack-stats.json
 script:
   - python ./manage.py migrate
   # codecov.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   # Install cx_Oracle (which depends on Oracle IC)
   - cd ./../backend/uclapi
   - pip3 install $(cat requirements.txt | grep "cx-Oracle")
-  - cp webpack-stats.sample.json webpack-stats.json
+  - cp webpack-stats.sample.json dashboard/static/webpack-stats.json
 script:
   - python ./manage.py migrate
   # codecov.io

--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -215,7 +215,10 @@ WEBPACK_LOADER = {
     'DEFAULT': {
         'CACHE': not DEBUG,
         'BUNDLE_DIR_NAME': '/',  # must end with slash
-        'STATS_FILE': os.path.join(BASE_DIR, 'dashboard/static/webpack-stats.json'),
+        'STATS_FILE': os.path.join(
+            BASE_DIR,
+            'static/webpack-stats.json'
+        ),
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
         'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
@@ -242,7 +245,7 @@ WEBPACK_LOADER = {
 #    of a person who has permission to upload new statics to
 #    S3.
 
-if strtobool(os.environ.get("AWS_S3_STATICS", "False")) or True:
+if strtobool(os.environ.get("AWS_S3_STATICS", "False")):
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_STORAGE_BUCKET_NAME = os.environ["AWS_S3_BUCKET_NAME"]

--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -215,7 +215,7 @@ WEBPACK_LOADER = {
     'DEFAULT': {
         'CACHE': not DEBUG,
         'BUNDLE_DIR_NAME': '/',  # must end with slash
-        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
+        'STATS_FILE': os.path.join(BASE_DIR, 'dashboard/static/webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
         'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
@@ -242,7 +242,7 @@ WEBPACK_LOADER = {
 #    of a person who has permission to upload new statics to
 #    S3.
 
-if strtobool(os.environ.get("AWS_S3_STATICS", "False")):
+if strtobool(os.environ.get("AWS_S3_STATICS", "False")) or True:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_STORAGE_BUCKET_NAME = os.environ["AWS_S3_BUCKET_NAME"]

--- a/backend/uclapi/uclapi/wsgi.py
+++ b/backend/uclapi/uclapi/wsgi.py
@@ -7,11 +7,11 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 """
 
-import os
-import urllib.request
-import shutil
-import fcntl
 import errno
+import fcntl
+import os
+import shutil
+import urllib.request
 
 import eventlet
 
@@ -39,8 +39,8 @@ WEBPACK_STATS_URL = "https://{}/static/webpack-stats.json".format(
 )
 WEBPACK_STATS_LOC = os.path.relpath('../static/webpack-stats.json')
 
-# check if another gunicorn process is
-# already writing to it
+# Check if another gunicorn process is already
+# writing to the WebPack stats file
 try:
     fcntl.flock(WEBPACK_STATS_LOC, fcntl.LOCK_EX | fcntl.LOCK_NB)
     with urllib.request.urlopen(WEBPACK_STATS_URL) as response:

--- a/backend/uclapi/uclapi/wsgi.py
+++ b/backend/uclapi/uclapi/wsgi.py
@@ -32,9 +32,12 @@ if os.environ.get("EVENTLET_NOPATCH") != 'True':
 
 # Download latest webpack-stats.json from S3
 # before starting WSGI
-WEBPACK_STATS_URL = "https://{}/static/webpack-stats.json".format(settings.AWS_S3_CUSTOM_DOMAIN)
-WEBPACK_STATS_LOC = os.path.relpath('../dashboard/static/webpack-stats.json')
-with urllib.request.urlopen(WEBPACK_STATS_URL) as response, open(WEBPACK_STATS_LOC, 'wb') as out_file:
-    shutil.copyfileobj(response, out_file)
+WEBPACK_STATS_URL = "https://{}/static/webpack-stats.json".format(
+    settings.AWS_S3_CUSTOM_DOMAIN
+)
+WEBPACK_STATS_LOC = os.path.relpath('../static/webpack-stats.json')
+with urllib.request.urlopen(WEBPACK_STATS_URL) as response:
+    with open(WEBPACK_STATS_LOC, 'wb') as out_file:
+        shutil.copyfileobj(response, out_file)
 
 application = get_wsgi_application()

--- a/backend/uclapi/uclapi/wsgi.py
+++ b/backend/uclapi/uclapi/wsgi.py
@@ -8,13 +8,15 @@ https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 """
 
 import os
+import urllib.request
+import shutil
 
 import eventlet
 
 from django.core.wsgi import get_wsgi_application
+from django.conf import settings
 
 from common.helpers import read_dotenv
-
 
 read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
 
@@ -27,5 +29,12 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "uclapi.settings")
 # This is because the patch breaks runserver.
 if os.environ.get("EVENTLET_NOPATCH") != 'True':
     eventlet.monkey_patch()
+
+# Download latest webpack-stats.json from S3
+# before starting WSGI
+WEBPACK_STATS_URL = "https://{}/static/webpack-stats.json".format(settings.AWS_S3_CUSTOM_DOMAIN)
+WEBPACK_STATS_LOC = os.path.relpath('../dashboard/static/webpack-stats.json')
+with urllib.request.urlopen(WEBPACK_STATS_URL) as response, open(WEBPACK_STATS_LOC, 'wb') as out_file:
+    shutil.copyfileobj(response, out_file)
 
 application = get_wsgi_application()

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = {
       sourceMap: true
     }),
     new BundleTracker({
-      filename: '../backend/uclapi/dashboard/static/webpack-stats.json'
+      filename: '../backend/uclapi/static/webpack-stats.json'
     })
   ],
   module: {
@@ -49,7 +49,7 @@ module.exports = {
     authorise: entryPointsPathPrefix + '/authorise.jsx',
   },
   output: {
-    path: path.resolve(__dirname, '../backend/uclapi/dashboard/static/'),
+    path: path.resolve(__dirname, '../backend/uclapi/static/'),
     filename: '[name].js'
   }
 };

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = {
       sourceMap: true
     }),
     new BundleTracker({
-      filename: '../backend/uclapi/webpack-stats.json'
+      filename: '../backend/uclapi/dashboard/static/webpack-stats.json'
     })
   ],
   module: {

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = {
       chunkFilename: "[id]-[contenthash].css"
     }),
     new BundleTracker({
-      filename: '../backend/uclapi/dashboard/static/webpack-stats.json'
+      filename: '../backend/uclapi/static/webpack-stats.json'
     }),
     new webpack.HashedModuleIdsPlugin()
   ],
@@ -72,7 +72,7 @@ module.exports = {
     vendors: ['react'],
   },
   output: {
-    path: path.resolve(__dirname, '../backend/uclapi/dashboard/static/'),
+    path: path.resolve(__dirname, '../backend/uclapi/static/'),
     filename: '[name]-[contenthash].js'
   }
 };

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = {
       chunkFilename: "[id]-[contenthash].css"
     }),
     new BundleTracker({
-      filename: '../backend/uclapi/webpack-stats.json'
+      filename: '../backend/uclapi/dashboard/static/webpack-stats.json'
     }),
     new webpack.HashedModuleIdsPlugin()
   ],


### PR DESCRIPTION
## What does this PR do?
* `webpack-stats.json` now generated in `dashboard/statics`
* `wsgi.py` now downloads `webpack-stats.json` from S3 upon run

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
For example: Need to run migrations as part of deployment
* `collectstatic` should upload `webpack-stats.json` to S3 bucket

## Anything else
