### PR TITLE
[WIP] Migrates us to a custom build of django-webpack-loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - postgresql
   - redis-server
 install:
-  - (sed '/cx.*/d' ./backend/uclapi/requirements.txt) | xargs -n 1 pip3 install
+  - (sed '/cx.*/d' ./backend/uclapi/requirements.txt | sed -e 's/^\-e //') | xargs -n 1 pip3 install
   - pip3 install codecov
 before_script:
   # Install Oracle Instant Client

--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -46,4 +46,4 @@ tldextract==2.2.0
 urllib3==1.24.1
 validators==0.12.4
 vine==1.2.0
--e git://github.com/uclapi/django-webpack-loader@master#egg=django-webpack-loader
+git+git://github.com/uclapi/django-webpack-loader@master#egg=django-webpack-loader

--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -15,7 +15,6 @@ django-dotenv==1.4.2
 django-mock-queries==2.1.1
 django-storages==1.7.1
 djangorestframework==3.9.1
-django-webpack-loader==0.6.0
 docutils==0.14
 eventlet==0.24.1
 gevent==1.4.0
@@ -47,3 +46,4 @@ tldextract==2.2.0
 urllib3==1.24.1
 validators==0.12.4
 vine==1.2.0
+-e git://github.com/uclapi/django-webpack-loader@master#egg=django-webpack-loader

--- a/backend/uclapi/requirements.txt
+++ b/backend/uclapi/requirements.txt
@@ -46,4 +46,4 @@ tldextract==2.2.0
 urllib3==1.24.1
 validators==0.12.4
 vine==1.2.0
-git+git://github.com/uclapi/django-webpack-loader@master#egg=django-webpack-loader
+-e git+git://github.com/uclapi/django-webpack-loader@master#egg=django-webpack-loader

--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -270,7 +270,9 @@ if strtobool(os.environ.get("AWS_S3_STATICS", "False")):
         'DEFAULT': {
             'CACHE': not DEBUG,
             'BUNDLE_DIR_NAME': './',  # must end with slash
-            'STATS_URL': "{}/webpack-stats.json".format(STATIC_URL),
+            'STATS_URL': "https://{}webpack-stats.json".format(
+                STATIC_URL
+            ),
             'POLL_INTERVAL': 0.1,
             'TIMEOUT': None,
             'IGNORE': [r'.+\.hot-update.js', r'.+\.map']

--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -265,24 +265,35 @@ if strtobool(os.environ.get("AWS_S3_STATICS", "False")):
         AWS_S3_CUSTOM_DOMAIN,
         AWS_LOCATION
     )
+    # Set up the WebPack loader for remote loading
+    WEBPACK_LOADER = {
+        'DEFAULT': {
+            'CACHE': not DEBUG,
+            'BUNDLE_DIR_NAME': './',  # must end with slash
+            'STATS_URL': "{}/webpack-stats.json".format(STATIC_URL),
+            'POLL_INTERVAL': 0.1,
+            'TIMEOUT': None,
+            'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
+        }
+    }
 else:
     # https://docs.djangoproject.com/en/1.10/howto/static-files/
     # The default Static URL is /static/ which is fine for when statics
     # have been built and placed into their respective folders.
     STATIC_URL = os.environ.get("STATIC_URL", '/static/')
 
-# Set up the WebPack loader
-WEBPACK_LOADER = {
-    'DEFAULT': {
-        'CACHE': not DEBUG,
-        'BUNDLE_DIR_NAME': './',  # must end with slash
-        'STATS_FILE': os.path.join(
-            BASE_DIR,
-            'static',
-            'webpack-stats.json'
-        ),
-        'POLL_INTERVAL': 0.1,
-        'TIMEOUT': None,
-        'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
+    # Set up the WebPack loader for local loading
+    WEBPACK_LOADER = {
+        'DEFAULT': {
+            'CACHE': not DEBUG,
+            'BUNDLE_DIR_NAME': './',  # must end with slash
+            'STATS_FILE': os.path.join(
+                BASE_DIR,
+                'static',
+                'webpack-stats.json'
+            ),
+            'POLL_INTERVAL': 0.1,
+            'TIMEOUT': None,
+            'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
+        }
     }
-}

--- a/backend/uclapi/uclapi/wsgi.py
+++ b/backend/uclapi/uclapi/wsgi.py
@@ -7,11 +7,7 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
 """
 
-import errno
 import os
-import shutil
-import time
-import urllib.request
 
 import eventlet
 
@@ -33,32 +29,5 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "uclapi.settings")
 # This is because the patch breaks runserver.
 if os.environ.get("EVENTLET_NOPATCH") != 'True':
     eventlet.monkey_patch()
-
-if not settings.DEBUG:
-    # Download latest webpack-stats.json from S3
-    # before starting WSGI
-    WEBPACK_STATS_URL = "https://{}/static/webpack-stats.json".format(
-        settings.AWS_S3_CUSTOM_DOMAIN
-    )
-    WEBPACK_STATS_LOC = os.path.join(BASE_DIR, "static", "webpack-stats.json")
-    WEBPACK_STATS_MIN_AGE = 60
-
-    should_download_webpack_stats = True
-    # First we check if the WebPack stats file is too recent.
-    # If so, we don't even bother trying to overwrite it.
-    if os.path.isfile(WEBPACK_STATS_LOC):
-        file_stats = os.stat(WEBPACK_STATS_LOC)
-        file_age = time.time() - file_stats.st_mtime
-        if file_age < WEBPACK_STATS_MIN_AGE:
-            should_download_webpack_stats = False
-
-    if should_download_webpack_stats:
-        try:
-            with open(WEBPACK_STATS_LOC, 'wb') as out_file:
-                with urllib.request.urlopen(WEBPACK_STATS_URL) as response:
-                    shutil.copyfileobj(response, out_file)
-        except IOError as e:
-            if e != errno.EACCES or e != errno.EAGAIN:
-                raise
 
 application = get_wsgi_application()

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -49,6 +49,7 @@ module.exports = {
     dashboard: entryPointsPathPrefix + '/dashboard.jsx',
     marketplace: entryPointsPathPrefix + '/marketplace.jsx',
     authorise: entryPointsPathPrefix + '/authorise.jsx',
+    vendors: ['react'],
   },
   output: {
     path: path.resolve(__dirname, '../backend/uclapi/static/'),


### PR DESCRIPTION
## What does this PR do?
Migrates to a custom build of `django-webpack-loader` that lets us provide a `STATIC_URL` which will play nicer with `gunicorn`.

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Deploy and restart the API

## Anything else
