### PR TITLE
Adding sensor ID to live map

### DIFF
--- a/backend/uclapi/workspaces/image_builder.py
+++ b/backend/uclapi/workspaces/image_builder.py
@@ -105,6 +105,7 @@ class ImageBuilder():
 
         for sensor_id, sensor_data in the_map["sensors"].items():
             node = etree.SubElement(bubble_overlay, "g")
+            node.attrib["id"] = sensor_id
             node.attrib["transform"] = "translate({},{})".format(
                 sensor_data["x_pos"],
                 sensor_data["y_pos"]

--- a/frontend/src/components/documentation/Routes/Workspaces/GetLiveImage.jsx
+++ b/frontend/src/components/documentation/Routes/Workspaces/GetLiveImage.jsx
@@ -38,10 +38,10 @@ let response = `
     <g transform="scale(0.02, 0.02)">
         <image width="28329.0" height="29882.0" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA7QAAA..."/>
         <g>
-            <g transform=""translate(13223.0,27477.0)">
+            <g id="603001" transform="translate(13223.0,27477.0)">
                 <circle r="128" fill="#FFC90E"/>
             </g>
-            <g transform="translate(13223.0,26708.0)">
+            <g id="603002" transform="translate(13223.0,26708.0)">
                 <circle r="128" fill="#FFC90E"/>
             </g>
             ...
@@ -119,7 +119,7 @@ export default class WorkspacesGetLiveImage extends React.Component {
                     codeExamples={responseCodeExample}>
                     <h2>Response</h2>
                     <p>
-                        The response will be XML SVG data that contains a base64-encoded PNG map (the same data that is returned by `/workspaces/images/map`) and vector circles designating which seats are free and occupied. An example of this returned data is on the right.
+                        The response will be XML SVG data that contains a base64-encoded PNG map (the same data that is returned by `/workspaces/images/map`) and vector circles designating which seats are free and occupied. Each &lt;g&gt; SVG element contains an ID that corresponds to the sensor ID, where additional information about the sensor can be retrieved via `/workspaces/sensors`. An example of this returned data is on the right.
                     </p>
                 </Topic>
             </div>


### PR DESCRIPTION
## What does this PR do?
Implements #1037 
Each <g> element in the SVG had an 'id' attribute which corresponds to the sensors id. Additional data on sensors can be retried from our Get Sensors (/workspaces/sensors) endpoint.
## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Rebuild docs.

## Anything else
