### PR TITLE
Unifies the way locking works

### DIFF
--- a/backend/uclapi/roombookings/helpers.py
+++ b/backend/uclapi/roombookings/helpers.py
@@ -90,7 +90,7 @@ def _get_paginated_bookings(page_token):
 def _paginated_result(query, page_number, pagination):
     try:
         lock = Lock.objects.all()[0]
-        curr = BookingA if not lock.a else BookingB
+        curr = BookingA if lock.a else BookingB
         all_bookings = curr.objects.filter(
             Q(bookabletype='CB') | Q(siteid='238') | Q(siteid='240'),
             **query

--- a/backend/uclapi/roombookings/management/commands/trigger_webhooks.py
+++ b/backend/uclapi/roombookings/management/commands/trigger_webhooks.py
@@ -25,10 +25,10 @@ class Command(BaseCommand):
         self.stdout.write("Triggering webhooks")
         session = FuturesSession()
 
-        # currently locked table is the old one, more recent one is not locked
+        # currently not locked table is the old one, more recent one is locked
         lock = Lock.objects.all()[0]  # there is only ever one lock
 
-        if lock.a:
+        if not lock.a:
             old_booking_table = BookingA
             new_booking_table = BookingB
         else:

--- a/backend/uclapi/roombookings/views.py
+++ b/backend/uclapi/roombookings/views.py
@@ -35,7 +35,7 @@ def get_rooms(request, *args, **kwargs):
     # - Anything centrally bookable
     # - All ICH rooms (Site IDs 238 and 240)
     lock = Lock.objects.all()[0]
-    curr = RoomA if not lock.a else RoomB
+    curr = RoomA if lock.a else RoomB
 
     # No filters provided, return all rooms serialised
     if reduce(lambda x, y: x or y, request_params.values()):
@@ -131,7 +131,7 @@ def get_bookings(request, *args, **kwargs):
     bookings = _get_paginated_bookings(page_token)
 
     lock = Lock.objects.all()[0]
-    curr = BookingA if not lock.a else BookingB
+    curr = BookingA if lock.a else BookingB
 
     bookings["count"] = curr.objects.filter(
         Q(bookabletype='CB') | Q(siteid='238') | Q(siteid='240'),
@@ -224,7 +224,7 @@ def get_free_rooms(request, *args, **kwargs):
     bookings = _get_paginated_bookings(page_token)["bookings"]
 
     lock = Lock.objects.all()[0]
-    curr = RoomA if not lock.a else RoomB
+    curr = RoomA if lock.a else RoomB
 
     # Get available rooms:
     # - Filtered by this academic year only


### PR DESCRIPTION
## What does this PR do?
previously it appears lock.a meant use bucket a for timetable but lock.a mean do not use a for bookings. We did not notice this when unfying locks.

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes/No

## :squirrel: Deploy notes
Run two caches to fix buckets as a safe measure

## Anything else
