### PR TITLE
Correctly deal with missing HTTP Headers

### DIFF
--- a/backend/uclapi/dashboard/views.py
+++ b/backend/uclapi/dashboard/views.py
@@ -19,12 +19,46 @@ from .tasks import add_user_to_mailing_list_task
 
 @csrf_exempt
 def shibboleth_callback(request):
+    # should auth user login or signup
+    # then redirect to dashboard homepage
+
+    # Sometimes UCL doesn't give us the expected headers.
+    # If a critical header is missing we error out.
+    # If non-critical headers are missing we simply put a placeholder string.
+    try:
+        # This is used to find the correct user
+        eppn = request.META['HTTP_EPPN']
+        # We don't really use cn but because it's unique in the DB we can't
+        # really put a place holder value.
+        cn = request.META['HTTP_CN']
+        # (aka UPI), also unique in the DB
+        employee_id = request.META['HTTP_EMPLOYEEID']
+    except KeyError:
+        response = HttpResponse(
+            (
+
+                "Error 400 - Bad Request. <br>"
+                "UCL has sent incomplete headers. If the issues persist please"
+                "contact the UCL API Team to rectify this."
+            )
+        )
+        response.status_code = 400
+        return response
+
+    # TODO: Ask UCL what on earth are they doing by missing out headers, and
+    # remind them we need to to be informed of these types of changes.
+    # TODO: log to sentry that fields were missing...
+    department = request.META.get('HTTP_DEPARTMENT', '')
+    given_name = request.META.get('HTTP_GIVENNAME', '')
+    display_name = request.META.get('HTTP_DISPLAYNAME', '')
+    groups = request.META.get('HTTP_UCLINTRANETGROUPS', '')
+
     # We first check whether the user is a member of any UCL Intranet Groups.
     # This is a quick litmus test to determine whether they should have
     # access to the dashboard.
     # We deny access to test accounts and alumni, neither of which have
     # this Shibboleth attribute.
-    if 'HTTP_UCLINTRANETGROUPS' not in request.META:
+    if not groups:
         response = HttpResponse(
             (
                 "Error 403 - denied. <br>"
@@ -34,17 +68,10 @@ def shibboleth_callback(request):
         response.status_code = 403
         return response
 
-    # should auth user login or signup
-    # then redirect to dashboard homepage
-    eppn = request.META['HTTP_EPPN']
-    groups = request.META['HTTP_UCLINTRANETGROUPS']
-    cn = request.META['HTTP_CN']
-    department = request.META.get('HTTP_DEPARTMENT', '')
-    given_name = request.META['HTTP_GIVENNAME']
-    display_name = request.META['HTTP_DISPLAYNAME']
-    employee_id = request.META['HTTP_EMPLOYEEID']
-
     try:
+        # TODO: Handle MultipleObjectsReturned exception.
+        # email field isn't unique at database level (on our side).
+        # Alternatively, switch to employee_id (which is unique).
         user = User.objects.get(email=eppn)
     except ObjectDoesNotExist:
         # create a new user
@@ -63,14 +90,17 @@ def shibboleth_callback(request):
 
         request.session["user_id"] = new_user.id
     else:
-        # user exists already, update values
-        request.session["user_id"] = user.id
-        user.full_name = display_name
-        user.given_name = given_name
+        # User exists already, so update the values if new ones are non-empty.
+        user = User.objects.get(email=eppn)
+        user.employee_id = employee_id
+        if display_name:
+            user.full_name = display_name
+        if given_name:
+            user.given_name = given_name
         if department:
             user.department = department
-        user.raw_intranet_groups = groups
-        user.employee_id = employee_id
+        if groups:
+            user.raw_intranet_groups = groups
         user.save()
 
     return redirect(dashboard)

--- a/backend/uclapi/oauth/views.py
+++ b/backend/uclapi/oauth/views.py
@@ -156,7 +156,7 @@ def shibcallback(request):
     department = request.META.get('HTTP_DEPARTMENT', '')
     given_name = request.META.get('HTTP_GIVENNAME', '')
     display_name = request.META.get('HTTP_DISPLAYNAME', '')
-    groups = request.get('HTTP_UCLINTRANETGROUPS', '')
+    groups = request.META.get('HTTP_UCLINTRANETGROUPS', '')
 
     # We check whether the user is a member of any UCL Intranet Groups.
     # This is a quick litmus test to determine whether they should be able to
@@ -631,7 +631,7 @@ def myapps_shibboleth_callback(request):
     department = request.META.get('HTTP_DEPARTMENT', '')
     given_name = request.META.get('HTTP_GIVENNAME', '')
     display_name = request.META.get('HTTP_DISPLAYNAME', '')
-    groups = request.get('HTTP_UCLINTRANETGROUPS', '')
+    groups = request.META.get('HTTP_UCLINTRANETGROUPS', '')
 
     try:
         user = User.objects.get(email=eppn)

--- a/backend/uclapi/oauth/views.py
+++ b/backend/uclapi/oauth/views.py
@@ -142,7 +142,7 @@ def shibcallback(request):
         # (aka UPI), also unique in the DB
         employee_id = request.META['HTTP_EMPLOYEEID']
     except KeyError:
-        response = JsonResponse({
+        response = PrettyJsonResponse({
             "ok": False,
             "error": ("UCL has sent incomplete headers. If the issues persist"
                       "please contact the UCL API Team to rectify this.")
@@ -617,7 +617,7 @@ def myapps_shibboleth_callback(request):
         # (aka UPI), also unique in the DB
         employee_id = request.META['HTTP_EMPLOYEEID']
     except KeyError:
-        response = JsonResponse({
+        response = PrettyJsonResponse({
             "ok": False,
             "error": ("UCL has sent incomplete headers. If the issues persist"
                       "please contact the UCL API Team to rectify this.")

--- a/frontend/src/components/documentation/Routes/OAuth/Authorise.jsx
+++ b/frontend/src/components/documentation/Routes/OAuth/Authorise.jsx
@@ -80,7 +80,7 @@ export default class Authorise extends React.Component {
                 description="Gets returned when you have not set a callback URL for your app." />
               <Cell
                 name="UCL has sent incomplete headers"
-                description="Gets if UCL sends us incomplete headers. If the issues persist please contact the UCL API Team to rectify this." />
+                description="Gets returned when UCL sends us incomplete headers. If the issues persist please contact the UCL API Team to rectify this." />
               </Table>
           </Topic>
         </div>

--- a/frontend/src/components/documentation/Routes/OAuth/Authorise.jsx
+++ b/frontend/src/components/documentation/Routes/OAuth/Authorise.jsx
@@ -78,6 +78,9 @@ export default class Authorise extends React.Component {
               <Cell
                 name="No callback URL set for this app."
                 description="Gets returned when you have not set a callback URL for your app." />
+              <Cell
+                name="UCL has sent incomplete headers"
+                description="Gets if UCL sends us incomplete headers. If the issues persist please contact the UCL API Team to rectify this." />
               </Table>
           </Topic>
         </div>

--- a/frontend/src/components/documentation/Routes/OAuth/UserData.jsx
+++ b/frontend/src/components/documentation/Routes/OAuth/UserData.jsx
@@ -85,7 +85,7 @@ export default class UserData extends React.Component {
               name="department"
               extra="string"
               example="Dept Of Computer Science"
-              description="Department the user belongs to." />
+              description="Department the user belongs to. Can be an empty string." />
             <Cell
               name="email"
               extra="string"
@@ -100,12 +100,12 @@ export default class UserData extends React.Component {
               name="full_name"
               extra="string"
               example="Martin Mrkvicka"
-              description="Full name of the user." />
+              description="Full name of the user. Can be an empty string." />
             <Cell
               name="department"
               extra="string"
               example="Dept Of Computer Science"
-              description="Department the user belongs to." />
+              description="Department the user belongs to. Can be an empty string." />
             <Cell
               name="cn"
               extra="string"
@@ -115,7 +115,7 @@ export default class UserData extends React.Component {
               name="given_name"
               extra="string"
               example="Martin"
-              description="Given first name of the user." />
+              description="Given first name of the user. Can be an empty string." />
             <Cell
               name="upi"
               extra="string"


### PR DESCRIPTION
## What does this PR do?
This patch provides a complete fix to issues that occur when UCL's shibboleth
instance does not return certain headers.

The following fields are considered critical and cannot be empty. Absence of
these parameters will result in a 400 error code being returned:
	1. eppn - used for finding user in DB. (We need to reconsider this...)
	2. cn - unique in DB
	3. employee_id - unique in DB, and used for determining is_student

The following fields are considered non-compulsory and instead replaced with an
empty string:
	1. department
	2. given_name
	3. display_name
	4. groups

This patch updates the documentation accordingly, and includes tests for certain
scenarios.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No - kind of. Those who rely on the department, given name, and display name being complete will now have this assumption broken.

Resolves #1602 and #1603