### PR TITLE
Allow alumni to use UCL API OAuth

### DIFF
--- a/backend/uclapi/oauth/tests.py
+++ b/backend/uclapi/oauth/tests.py
@@ -704,41 +704,6 @@ class ViewsTestCase(TestCase):
             "shibtests"
         )
 
-    def test_invalid_or_alumni_account(self):
-        dev_user_ = User.objects.create(
-            email="testdev@ucl.ac.uk",
-            cn="test",
-            given_name="Test Dev",
-            employee_id='testdev01'
-        )
-        app_ = App.objects.create(
-            user=dev_user_,
-            name="An App",
-            callback_url="www.somecallbackurl.com/callback"
-        )
-
-        signer = signing.TimestampSigner()
-        # Generate a random state for testing
-        state = ''.join(
-            random.choices(string.ascii_letters + string.digits, k=32)
-        )
-        data = app_.client_id + state
-        signed_data = signer.sign(data)
-
-        response = self.client.get(
-            '/oauth/shibcallback',
-            {
-                'appdata': signed_data
-            },
-            HTTP_EPPN='testxxx@ucl.ac.uk',
-            HTTP_CN='testxxx',
-            HTTP_DEPARTMENT='Dept of Alumni',
-            HTTP_GIVENNAME='Test',
-            HTTP_DISPLAYNAME='Test User',
-            HTTP_EMPLOYEEID='xxxtest01',
-        )
-        self.assertEqual(response.status_code, 403)
-
 
 class AppHelpersTestCase(TestCase):
     def test_generate_random_verification_code(self):

--- a/backend/uclapi/oauth/views.py
+++ b/backend/uclapi/oauth/views.py
@@ -158,25 +158,10 @@ def shibcallback(request):
     display_name = request.META.get('HTTP_DISPLAYNAME', '')
     groups = request.META.get('HTTP_UCLINTRANETGROUPS', '')
 
-    # We check whether the user is a member of any UCL Intranet Groups.
-    # This is a quick litmus test to determine whether they should be able to
-    # use an OAuth application.
-    # We deny access to alumni, which does not have this Shibboleth attribute.
-    # Test accounts also do not have this attribute, but we can check the
-    # department attribute for the Shibtests department.
-    # This lets App Store reviewers log in to apps that use the UCL API.
-    if not groups:
-        if department == "Shibtests" or eppn == SHIB_TEST_USER:
-            groups = "shibtests"
-        else:
-            response = HttpResponse(
-                (
-                    "Error 403 - denied. <br>"
-                    "Unfortunately, alumni are not permitted to use UCL Apps."
-                )
-            )
-            response.status_code = 403
-            return response
+    # TODO: Find a way to block access to alumni (do we need this?) without
+    # blocking access to new students too.
+    if not groups and (department  == "Shibtests" or eppn == SHIB_TEST_USER):
+        groups = "shibtests"
 
     # If a user has never used the API before then we need to sign them up
     try:

--- a/backend/uclapi/oauth/views.py
+++ b/backend/uclapi/oauth/views.py
@@ -160,7 +160,7 @@ def shibcallback(request):
 
     # TODO: Find a way to block access to alumni (do we need this?) without
     # blocking access to new students too.
-    if not groups and (department  == "Shibtests" or eppn == SHIB_TEST_USER):
+    if not groups and (department == "Shibtests" or eppn == SHIB_TEST_USER):
         groups = "shibtests"
 
     # If a user has never used the API before then we need to sign them up


### PR DESCRIPTION
## What does this PR do?

In commit a81d6f580f3a3df04cb6839a60e326a63dd14359 an assumption was made that
a lack of the groups header meant that the user was an alumnus. This is not
strictly true: new students can also have a missing group header.
This patch partially reverts the above commit - we still deny access to the
dashboard for alumni (and consequently new students). However, this patch now
allows alumni (and consequenty new students) to successfully log into apps that
user our OAuth system.

## ✅ Pull Request checklist

- [x ] Is this code complete?
- [ x] Are tests done/modified?
- [ x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No - but alumni are now allows to use OAuth apps.