### PR TITLE
Revert to Python based personal timetable generator

### DIFF
--- a/backend/uclapi/timetable/management/commands/test_personal_timetable.py
+++ b/backend/uclapi/timetable/management/commands/test_personal_timetable.py
@@ -3,6 +3,7 @@ import time
 from django.core.management.base import BaseCommand
 import json
 
+from timetable.app_helpers import get_student_timetable
 from timetable.personal_timetable import get_personal_timetable
 
 
@@ -10,10 +11,13 @@ class Command(BaseCommand):
 
     help = 'Clones timetable related dbs to speed up queries'
 
+    def add_arguments(self, parser):
+        parser.add_argument('upi')
+
     def handle(self, *args, **options):
-        upi = input("Please enter the student UPI: ")
+        upi = options['upi']
         start_time = time.time()
-        tt = get_personal_timetable(upi)
+        # tt = get_personal_timetable(upi)
+        tt = get_student_timetable(upi)
         elapsed_time = time.time() - start_time
-        print(elapsed_time)
         print(json.dumps(tt))


### PR DESCRIPTION
## Summary
As we are unable to audit the SQL that generates the timetable a revert to
Python allows us to identify the issues and fix them in the future.
## Test Plan
Seems to be no worse than the original. Although check for `TabError`s
please, I forget to do `set nopaste` in Vim which caused some issues...