### PR TITLE
Fixed the parsing of the image from the content

### DIFF
--- a/backend/uclapi/dashboard/management/commands/update_medium.py
+++ b/backend/uclapi/dashboard/management/commands/update_medium.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
 
             if content.startswith("<figure><img"):
                 link = content[25:]
-                split = link.split(" />")
+                split = link.split('" />')
                 link = split[0]
 
             pipe.set(redis_key_title, title)


### PR DESCRIPTION
## What does this PR do?
When retrieving the image from the <content> tag in the medium article api, i was accidentally picking up a floating " which was preventing the images from correctly being linked to on the frontend so I changed it so it doesnt have this anymore.

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
Will need to run update_medium.py

## Anything else
