### PR TITLE
🐶 hound-specific eslint config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -13,6 +13,6 @@ scss:
 
 eslint:
   enabled: true
-  config_file: frontend/.eslintrc
+  config_file: frontend/.eslintrc.hound.json
   ignore_file: frontend/.eslintignore
   version: 6.8.0

--- a/frontend/.eslintrc.hound.json
+++ b/frontend/.eslintrc.hound.json
@@ -80,7 +80,7 @@
         "peerDependencies": false
       }
     ],
-    "security/detect-non-literal-require": "off", // until https://github.com/nodesecurity/eslint-plugin-security/pull/32 is merged
+    "security/detect-non-literal-require": "off",
     "security/detect-object-injection": "off"
   },
   "plugins": [
@@ -88,7 +88,6 @@
     "import",
     "security",
     "no-secrets",
-    // "json-format", Hound doesn't support this
     "sonarjs"
   ],
   "parser": "babel-eslint",
@@ -98,34 +97,6 @@
     }
   },
   "settings": {
-    "import/resolver": {
-      "webpack": "webpack.prod.js",
-      "alias": {
-        "map": [
-          [
-            "Images",
-            "./src/images"
-          ],
-          [
-            "Layout",
-            "./src/components/layout"
-          ],
-          [
-            "Styles",
-            "./src/sass"
-          ]
-        ],
-        "extensions": [
-          "jpg",
-          "png",
-          "svg",
-          "jpeg",
-          "js",
-          "jsx",
-          "scss"
-        ]
-      }
-    },
     "react": {
       "version": "detect"
     }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,147 @@
+{
+  "env": {
+    "node": true,
+    "browser": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:import/typescript",
+    "plugin:security/recommended",
+    "plugin:sonarjs/recommended"
+  ],
+  "rules": {
+    "semi": [
+      "error",
+      "never"
+    ],
+    "quotes": [
+      "error",
+      "backtick"
+    ],
+    "comma-dangle": [
+      "error",
+      "always-multiline"
+    ],
+    "no-var": "error",
+    "prefer-const": "error",
+    "max-len": [
+      "warn",
+      {
+        "code": 80
+      }
+    ],
+    "object-property-newline": "error",
+    "no-secrets/no-secrets": "error",
+    "react/jsx-indent-props": [
+      "error",
+      2
+    ],
+    "react/jsx-closing-bracket-location": [
+      "error"
+    ],
+    "react/static-property-placement": [
+      "error",
+      "static public field"
+    ],
+    "react/jsx-fragments": [
+      "error",
+      "syntax"
+    ],
+    "react/jsx-boolean-value": [
+      "error",
+      "never"
+    ],
+    "react/destructuring-assignment": [
+      "warn",
+      "always"
+    ],
+    "react/jsx-no-bind": [
+      "error",
+      {
+        "ignoreRefs": true
+      }
+    ],
+    "react/jsx-max-props-per-line": [
+      "warn",
+      {
+        "maximum": 1,
+        "when": "multiline"
+      }
+    ],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "packageDir": "./",
+        "devDependencies": true,
+        "optionalDependencies": false,
+        "peerDependencies": false
+      }
+    ],
+    "security/detect-non-literal-require": "off",
+    "security/detect-object-injection": "off"
+  },
+  "plugins": [
+    "react",
+    "import",
+    "security",
+    "no-secrets",
+    "json-format",
+    "sonarjs",
+    "disable"
+  ],
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "overrides": [
+    {
+      "files": [
+        "*.json"
+      ],
+      "settings": {
+        "disable/plugins": [
+          "no-secrets"
+        ]
+      }
+    }
+  ],
+  "processor": "disable/disable",
+  "settings": {
+    "import/resolver": {
+      "webpack": "./webpack.prod.js",
+      "alias": {
+        "map": [
+          [
+            "Images",
+            "./src/images"
+          ],
+          [
+            "Layout",
+            "./src/components/layout"
+          ],
+          [
+            "Styles",
+            "./src/sass"
+          ]
+        ],
+        "extensions": [
+          "jpg",
+          "png",
+          "svg",
+          "jpeg",
+          "js",
+          "jsx",
+          "scss"
+        ]
+      }
+    },
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6330,6 +6330,16 @@
         }
       }
     },
+    "eslint-plugin-disable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-disable/-/eslint-plugin-disable-2.0.1.tgz",
+      "integrity": "sha512-nM46IxpAD1Lh1ka/iQ6CTYfBaAp4EzM5chvMMiDpmfKh7JNEnzvPK4D2FSZBLXVTOR/AT7Wov51eucyNisCVBA==",
+      "dev": true,
+      "requires": {
+        "eslint": ">=0.16.0",
+        "resolve": "^1.1.6"
+      }
+    },
     "eslint-plugin-es": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,6 +83,7 @@
     "eslint": "^7.4.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-webpack": "^0.12.2",
+    "eslint-plugin-disable": "^2.0.1",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-json-format": "^2.0.1",
     "eslint-plugin-no-secrets": "^0.6.8",

--- a/frontend/test-hound.js
+++ b/frontend/test-hound.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+// hound should not throw any errors
+
+export default React

--- a/frontend/test-hound.js
+++ b/frontend/test-hound.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-// hound should not throw any errors
-
-export default React


### PR DESCRIPTION
## What does this PR do?
Add special eslint config for Hound, because Hound cannot resolve webpack alias paths.

See:

* https://github.com/uclapi/uclapi/pull/2524#issuecomment-657206118
* https://github.com/uclapi/uclapi/pull/2570#issuecomment-657206130

## ✅ Pull Request checklist

- [ ] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes/No

## :squirrel: Deploy notes
For example: Need to run migrations as part of deployment

## Anything else
