### PR TITLE
✂  Decouple warning & error pages from django

### DIFF
--- a/backend/uclapi/dashboard/templates/404.html
+++ b/backend/uclapi/dashboard/templates/404.html
@@ -4,11 +4,11 @@
 
 <head>
 
-  <title>Warning | UCL API</title>
+  <title>Not Found | UCL API</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900" rel="stylesheet">
-  {% render_bundle 'warning' 'css' %}
+  {% render_bundle '404' 'css' %}
 </head>
 
 
@@ -16,7 +16,7 @@
   <div class="app"></div>
   <script src="https://use.fontawesome.com/c70d56d6fc.js"></script>
   {% render_bundle 'vendors' 'js' %}
-  {% render_bundle 'warning' 'js' %}
+  {% render_bundle '404' 'js' %}
 </body>
 
 </html>

--- a/backend/uclapi/dashboard/templates/500.html
+++ b/backend/uclapi/dashboard/templates/500.html
@@ -4,11 +4,11 @@
 
 <head>
 
-  <title>Warning | UCL API</title>
+  <title>Error | UCL API</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900" rel="stylesheet">
-  {% render_bundle 'warning' 'css' %}
+  {% render_bundle '500' 'css' %}
 </head>
 
 
@@ -16,7 +16,7 @@
   <div class="app"></div>
   <script src="https://use.fontawesome.com/c70d56d6fc.js"></script>
   {% render_bundle 'vendors' 'js' %}
-  {% render_bundle 'warning' 'js' %}
+  {% render_bundle '500' 'js' %}
 </body>
 
 </html>

--- a/backend/uclapi/dashboard/templates/about.html
+++ b/backend/uclapi/dashboard/templates/about.html
@@ -1,24 +1,22 @@
 {% load render_bundle from webpack_loader %}
 <!DOCTYPE html>
 <html>
+
 <head>
 
   <title>UCL API</title>
 
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900" rel="stylesheet">
   {% render_bundle 'about' 'css' %}
 </head>
 
 
 <body>
-
-  <script>
-    window.initialData = {{ initial_data|safe }};
-  </script>
   <div class="app"></div>
   <script src="https://use.fontawesome.com/c70d56d6fc.js"></script>
   {% render_bundle 'vendors' 'js' %}
   {% render_bundle 'about' 'js' %}
 </body>
+
 </html>

--- a/backend/uclapi/dashboard/views.py
+++ b/backend/uclapi/dashboard/views.py
@@ -124,7 +124,7 @@ def dashboard(request):
         if request.method != "POST":
             return render(request, "agreement.html", {
                 'fair_use': FAIR_USE_POLICY
-                })
+            })
 
         try:
             agreement = strtobool(request.POST["agreement"])
@@ -185,9 +185,7 @@ def dashboard(request):
 
 @ensure_csrf_cookie
 def about(request):
-    return render(request, 'about.html', {
-        'initial_data': {}
-    })
+    return render(request, 'about.html')
 
 
 @ensure_csrf_cookie
@@ -218,38 +216,16 @@ def documentation(request):
 
 @ensure_csrf_cookie
 def warning(request):
-    return render(request, 'warning.html', {
-        'initial_data': {
-            'title': "Please note you are not fully logged out!",
-            'content': ["You have been logged out from UCL API. However "
-                        + "in order to be fully logged out of all UCL services "
-                        + "you need to close your browser completely and re-open.",
-                        "Thank you! Click here to go back to the front page:"]
-        }
-    })
+    return render(request, 'warning.html')
 
 
 @ensure_csrf_cookie
 def error_404_view(request, exception):
-    return render(request, 'warning.html', {
-        'initial_data': {
-            'title': "Error 404",
-            'content': ["Oops we cannot seem to find that page! ",
-                        "Please click below to go back to the front page:"]
-        }
-    })
+    return render(request, '404.html')
 
 
 def error_500_view(request):
-    return render(request, 'warning.html', {
-        'initial_data': {
-            'title': "Error 500",
-            'content': ["Oops... something went wrong! Sorry for the inconvenience. ",
-                        "Our team is working on it, if you have an urgent concern please get "
-                        + "in touch with us at isd.apiteam@ucl.ac.uk",
-                        "Please click below to go back to the front page:"]
-        }
-    })
+    return render(request, '500.html')
 
 
 def custom_page_not_found(request):

--- a/frontend/src/components/layout/Warning.jsx
+++ b/frontend/src/components/layout/Warning.jsx
@@ -1,0 +1,63 @@
+import warning from 'Images/warning/warning.svg'
+import {
+  Button,
+  Column,
+  Container,
+  Footer,
+  ImageView,
+  NavBar,
+  Row,
+  TextView,
+} from 'Layout/Items.jsx'
+import React from 'react'
+import 'Styles/common/uclapi.scss'
+import 'Styles/navbar.scss'
+
+const Warning = ({ title, content }) => (
+  <>
+    <NavBar isScroll={false} />
+
+    {/* Warning message */}
+
+    <Container styling="splash-parallax" height="600px">
+      <Row 
+        width="2-3"
+        horizontalAlignment="center"
+        verticalAlignment="center"
+      >
+        
+        <Column width="1-2" className="default">
+          <ImageView
+            src={warning}
+            width="367px"
+            height="405px"
+            description="large exclamation point, warning!"
+          />
+        </Column>
+
+        <Column width="1-2" alignItems="column">
+          <TextView 
+            heading="1"
+            text={title}
+            align="left"
+          />
+          {typeof content === `string`
+            ? (
+              <TextView 
+                heading="3"
+                text={content}
+                align="left"
+              />
+            )
+            : content}
+          <Button link={`/`} centred>
+            Home
+          </Button>
+        </Column>
+      </Row>
+    </Container>
+    <Footer />
+  </>
+)
+
+export default Warning

--- a/frontend/src/pages/404.jsx
+++ b/frontend/src/pages/404.jsx
@@ -1,0 +1,15 @@
+import Warning from 'Layout/Warning.jsx'
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const NotFoundPage = () => (
+  <Warning
+    title="Error 404"
+    content="Oops we cannot seem to find that page! Please click below to go back to the front page:"
+  />
+)
+
+ReactDOM.render(
+  <NotFoundPage />,
+  document.querySelector(`.app`)
+)

--- a/frontend/src/pages/500.jsx
+++ b/frontend/src/pages/500.jsx
@@ -1,0 +1,15 @@
+import Warning from 'Layout/Warning.jsx'
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const InternalServerErrorPage = () => (
+  <Warning
+    title="Error 500"
+    content="Oops... something went wrong! Sorry for the inconvenience. Our team is working on it, if you have an urgent concern please get in touch with us at isd.apiteam@ucl.ac.uk. Click below to go back to the front page:"
+  />
+)
+
+ReactDOM.render(
+  <InternalServerErrorPage />,
+  document.querySelector(`.app`)
+)

--- a/frontend/src/pages/Warning.jsx
+++ b/frontend/src/pages/Warning.jsx
@@ -1,74 +1,15 @@
-import warning from 'Images/warning/warning.svg'
-import {
-  Button,
-  Column,
-  Container,
-  Footer,
-  ImageView,
-  NavBar,
-  Row,
-  TextView,
-} from 'Layout/Items.jsx'
+import Warning from 'Layout/Warning.jsx'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import 'Styles/common/uclapi.scss'
-import 'Styles/navbar.scss'
 
-const Warning = () => {
-  const title = window.initialData.title
-  const content = window.initialData.content
-
-  return (
-    <>
-      <NavBar isScroll={false} />
-
-      {/* Warning message */}
-
-      <Container styling="splash-parallax" height="600px">
-        <Row 
-          width="2-3"
-          horizontalAlignment="center"
-          verticalAlignment="center"
-        >
-          
-          <Column width="1-2" className="default">
-            <ImageView
-              src={warning}
-              width="367px"
-              height="405px"
-              description="large exclamation point, warning!"
-            />
-          </Column>
-
-          <Column width="1-2" alignItems="column">
-            <TextView 
-              heading="1"
-              text={title}
-              align="left"
-            />
-            {content.map((line, key) =>
-              <TextView 
-                heading="3"
-                text={line}
-                align="left"
-                key={key}
-              />
-            )}
-            <Button
-              link={`/`} 
-              centred 
-            >
-              Home
-            </Button>
-          </Column>
-        </Row>
-      </Container>
-      <Footer />
-    </>
-  )
-}
+const WarningPage = () => (
+  <Warning
+    title="Please note you are not fully logged out!"
+    content="You have been logged out from UCL API. However, in order to be fully logged out of all UCL services, you need to close your browser completely and re-open it. Thank you! Click here to go back to the front page:"
+  />
+)
 
 ReactDOM.render(
-  <Warning />,
+  <WarningPage />,
   document.querySelector(`.app`)
 )

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -54,6 +54,8 @@ module.exports = {
     marketplace: entryPointsPathPrefix + `/Marketplace.jsx`,
     authorise: entryPointsPathPrefix + `/Authorise.jsx`,
     warning: entryPointsPathPrefix + `/Warning.jsx`,
+    404: entryPointsPathPrefix + `/404.jsx`,
+    500: entryPointsPathPrefix + `/500.jsx`,
     settings: entryPointsPathPrefix + `/AppSettings.jsx`,
     vendors: [`react`],
   },

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -93,6 +93,8 @@ module.exports = {
     marketplace: entryPointsPathPrefix + `/Marketplace.jsx`,
     authorise: entryPointsPathPrefix + `/Authorise.jsx`,
     warning: entryPointsPathPrefix + `/Warning.jsx`,
+    404: entryPointsPathPrefix + `/404.jsx`,
+    500: entryPointsPathPrefix + `/500.jsx`,
     settings: entryPointsPathPrefix + `/AppSettings.jsx`,
     vendors: [`react`],
   },


### PR DESCRIPTION
## What does this PR do?

The following 3 pages no longer require any `initial_data` supplied by Django. They're now static, as they should be.

* Warning - warns the user they are not completely logged out on all UCL services
* Error 404
* Error 500

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes

Redeploy frontend

## Anything else

I'm not sure why codecov is failing even though the change in coverage is 0.00%.
