### PR TITLE
✂ Decouple dashboard from Django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/backend/uclapi/.flake8.ini
+++ b/backend/uclapi/.flake8.ini
@@ -1,7 +1,9 @@
 [flake8]
 
 # To run a test for violations run `flake8 --config .flake8.ini`
-ignore = BLK100
+ignore =
+	BLK100,
+	W503
 exclude = 
 	migrations,
 	venv,

--- a/backend/uclapi/dashboard/api_applications.py
+++ b/backend/uclapi/dashboard/api_applications.py
@@ -360,3 +360,61 @@ def update_scopes(request):
             "success": True,
             "message": "Scope successfully changed.",
         })
+
+
+def get_apps(request):
+    if request.method != "GET":
+        response = PrettyJsonResponse({
+            "success": False,
+            "error": "Request is not of method GET"
+        })
+        response.status_code = 400
+        return response
+
+    try:
+        user_id = request.session["user_id"]
+    except (KeyError, AttributeError):
+        response = PrettyJsonResponse({
+            "success": False,
+            "message": "User ID not set in session. Please log in again."
+        })
+        response.status_code = 400
+        return response
+
+    user = get_user_by_id(user_id)
+
+    user_meta = {
+        "name": user.full_name,
+        "cn": user.cn,
+        "department": user.department,
+        "intranet_groups": user.raw_intranet_groups,
+        "apps": []
+    }
+
+    user_apps = App.objects.filter(user=user, deleted=False)
+
+    s = Scopes()
+
+    for app in user_apps:
+        user_meta["apps"].append({
+            "name": app.name,
+            "id": app.id,
+            "token": app.api_token,
+            "created": app.created,
+            "updated": app.last_updated,
+            "oauth": {
+                "client_id": app.client_id,
+                "client_secret": app.client_secret,
+                "callback_url": app.callback_url,
+                "scopes": s.scope_dict_all(app.scope.scope_number)
+            },
+            "webhook": {
+                "verification_secret": app.webhook.verification_secret,
+                "url": app.webhook.url,
+                "siteid": app.webhook.siteid,
+                "roomid": app.webhook.roomid,
+                "contact": app.webhook.contact
+            }
+        })
+
+    return PrettyJsonResponse(user_meta)

--- a/backend/uclapi/dashboard/templates/dashboard.html
+++ b/backend/uclapi/dashboard/templates/dashboard.html
@@ -1,12 +1,14 @@
 {% load render_bundle from webpack_loader %}
 <!DOCTYPE html>
 <html>
+
 <head>
 
   <title>UCL API Dashboard</title>
 
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
-  <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/pure-min.css" integrity="sha384-UQiGfs9ICog+LwheBSRCt1o5cbyKIHbwjWscjemyBMT9YCUMZffs6UqUTd0hObXD" crossorigin="anonymous">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
+  <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/pure-min.css"
+    integrity="sha384-UQiGfs9ICog+LwheBSRCt1o5cbyKIHbwjWscjemyBMT9YCUMZffs6UqUTd0hObXD" crossorigin="anonymous">
   <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-min.css">
   <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
   {% render_bundle 'dashboard' 'css' %}
@@ -14,13 +16,10 @@
 
 
 <body>
-
-  <script>
-    window.initialData = {{ initial_data|safe }};
-  </script>
   <div class="app"></div>
   <script src="https://use.fontawesome.com/c70d56d6fc.js"></script>
   {% render_bundle 'vendors' 'js' %}
   {% render_bundle 'dashboard' 'js' %}
 </body>
+
 </html>

--- a/backend/uclapi/dashboard/tests.py
+++ b/backend/uclapi/dashboard/tests.py
@@ -99,17 +99,23 @@ class MediumArticleScraperTestCase(TestCase):
 
 
 class DashboardTestCase(TestCase):
+
+    TEST_USER = dict(
+        email="test@test.com",
+        full_name="Test testington",
+        given_name="test",
+        department="CS",
+        cn="test",
+        raw_intranet_groups="none",
+        employee_id=12345
+    )
+
+    TEST_APP = dict(name="An App")
+
     def setUp(self):
-        u = User.objects.create(email="test@test.com",
-                                full_name="Test testington",
-                                given_name="test",
-                                department="CS",
-                                cn="test",
-                                raw_intranet_groups="none",
-                                employee_id=12345
-                                )
+        u = User.objects.create(**DashboardTestCase.TEST_USER)
         App.objects.create(user=u,
-                           name="An App")
+                           **DashboardTestCase.TEST_APP)
         session = self.client.session
         session["user_id"] = u.id
         session.save()
@@ -155,6 +161,41 @@ class DashboardTestCase(TestCase):
     def test_safe_url(self):
         assert not is_url_unsafe("https://mytestapp.com/callback")
         assert not is_url_unsafe("https://uclapiexample.com/callback")
+
+    def test_get_apps(self):
+        with patch.dict(
+            'os.environ',
+            {'SHIBBOLETH_ROOT': "http://rooturl.com"}
+        ):
+            session = self.client.session
+            session.save()
+
+            res = self.client.get('/dashboard/api/apps/')
+            self.assertEqual(res.status_code, 200)
+
+            content = json.loads(res.content.decode())
+            self.assertEqual(
+                content["name"],
+                DashboardTestCase.TEST_USER["full_name"]
+            )
+            self.assertEqual(
+                content["cn"],
+                DashboardTestCase.TEST_USER["cn"]
+            )
+            self.assertEqual(
+                content["department"],
+                DashboardTestCase.TEST_USER["department"]
+            )
+            self.assertEqual(
+                content["intranet_groups"],
+                DashboardTestCase.TEST_USER["raw_intranet_groups"]
+            )
+            self.assertTrue(isinstance(content["apps"], list))
+            self.assertEqual(len(content["apps"]), 1)
+            self.assertEqual(
+                content["apps"][0]["name"],
+                DashboardTestCase.TEST_APP["name"]
+            )
 
 
 class FakeShibbolethMiddleWareTestCase(TestCase):

--- a/backend/uclapi/dashboard/tests.py
+++ b/backend/uclapi/dashboard/tests.py
@@ -146,8 +146,6 @@ class DashboardTestCase(TestCase):
 
         res = self.client.post('/dashboard/', {'agreement': 'True'})
         self.assertTemplateUsed(res, "dashboard.html")
-        self.assertContains(res, "An App")
-        self.assertContains(res, "Test testington")
 
     def test_unsafe_urls(self):
         assert is_url_unsafe("ftp://test.com")

--- a/backend/uclapi/dashboard/urls.py
+++ b/backend/uclapi/dashboard/urls.py
@@ -2,13 +2,14 @@ from django.conf.urls import url
 
 from dashboard.api_applications import (
     create_app, delete_app, regenerate_app_token, rename_app, set_callback_url,
-    update_scopes
+    update_scopes, get_apps
 )
 
 from . import views, webhook_views
 
 urlpatterns = [
     url(r'^$', views.dashboard),
+    url(r'api/apps/$', get_apps),
     url(r'api/create/$', create_app),
     url(r'api/rename/$', rename_app),
     url(r'api/regen/$', regenerate_app_token),

--- a/backend/uclapi/dashboard/views.py
+++ b/backend/uclapi/dashboard/views.py
@@ -1,19 +1,16 @@
-import json
 import os
 from distutils.util import strtobool
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.utils.http import quote
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 
-from oauth.scoping import Scopes
 from uclapi.settings import FAIR_USE_POLICY
 
 from .app_helpers import get_temp_token, get_articles
-from .models import App, User
+from .models import User
 from .tasks import add_user_to_mailing_list_task
 
 
@@ -124,7 +121,7 @@ def dashboard(request):
         if request.method != "POST":
             return render(request, "agreement.html", {
                 'fair_use': FAIR_USE_POLICY
-                })
+            })
 
         try:
             agreement = strtobool(request.POST["agreement"])
@@ -143,44 +140,7 @@ def dashboard(request):
                 "error": "You must agree to the fair use policy"
             })
 
-    user_meta = {
-        "name": user.full_name,
-        "cn": user.cn,
-        "department": user.department,
-        "intranet_groups": user.raw_intranet_groups,
-        "apps": []
-    }
-
-    user_apps = App.objects.filter(user=user, deleted=False)
-
-    s = Scopes()
-
-    for app in user_apps:
-        user_meta["apps"].append({
-            "name": app.name,
-            "id": app.id,
-            "token": app.api_token,
-            "created": app.created,
-            "updated": app.last_updated,
-            "oauth": {
-                "client_id": app.client_id,
-                "client_secret": app.client_secret,
-                "callback_url": app.callback_url,
-                "scopes": s.scope_dict_all(app.scope.scope_number)
-            },
-            "webhook": {
-                "verification_secret": app.webhook.verification_secret,
-                "url": app.webhook.url,
-                "siteid": app.webhook.siteid,
-                "roomid": app.webhook.roomid,
-                "contact": app.webhook.contact
-            }
-        })
-
-    initial_data = json.dumps(user_meta, cls=DjangoJSONEncoder)
-    return render(request, 'dashboard.html', {
-        'initial_data': initial_data
-    })
+    return render(request, 'dashboard.html')
 
 
 @ensure_csrf_cookie
@@ -221,10 +181,12 @@ def warning(request):
     return render(request, 'warning.html', {
         'initial_data': {
             'title': "Please note you are not fully logged out!",
-            'content': ["You have been logged out from UCL API. However "
-                        + "in order to be fully logged out of all UCL services "
-                        + "you need to close your browser completely and re-open.",
-                        "Thank you! Click here to go back to the front page:"]
+            'content': [
+                "You have been logged out from UCL API. However "
+                + "in order to be fully logged out of all UCL services "
+                + "you need to close your browser completely and re-open.",
+                "Thank you! Click here to go back to the front page:"
+            ]
         }
     })
 
@@ -244,10 +206,13 @@ def error_500_view(request):
     return render(request, 'warning.html', {
         'initial_data': {
             'title': "Error 500",
-            'content': ["Oops... something went wrong! Sorry for the inconvenience. ",
-                        "Our team is working on it, if you have an urgent concern please get "
-                        + "in touch with us at isd.apiteam@ucl.ac.uk",
-                        "Please click below to go back to the front page:"]
+            'content': [
+                "Oops... something went wrong! Sorry for the inconvenience. ",
+                "Our team is working on it, "
+                + "if you have an urgent concern please get "
+                + "in touch with us at isd.apiteam@ucl.ac.uk",
+                "Please click below to go back to the front page:"
+            ]
         }
     })
 

--- a/backend/uclapi/dashboard/views.py
+++ b/backend/uclapi/dashboard/views.py
@@ -6,10 +6,9 @@ from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.utils.http import quote
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
-
 from uclapi.settings import FAIR_USE_POLICY
 
-from .app_helpers import get_temp_token, get_articles
+from .app_helpers import get_articles, get_temp_token
 from .models import User
 from .tasks import add_user_to_mailing_list_task
 
@@ -109,8 +108,8 @@ def dashboard(request):
         user_id = request.session["user_id"]
     except KeyError:
         url = os.environ["SHIBBOLETH_ROOT"] + "/Login?target="
-        param = (request.build_absolute_uri(request.path) +
-                 "user/login.callback")
+        param = (request.build_absolute_uri(request.path)
+                 + "user/login.callback")
         param = quote(param)
         url = url + param
         return redirect(url)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11647,10 +11647,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -12329,6 +12328,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
       }
     },
     "require-directory": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "include-media": "^1.4.9",
     "js-cookie": "^2.2.1",
     "prop-types": "^15.7.2",
+    "qs": "^6.9.4",
     "rc-collapse": "^2.0.0",
     "react": "^16.13.1",
     "react-autosuggest": "^10.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     ],
     "../**/*.py": [
       "autopep8 --in-place --global-config ../backend/uclapi/.flake8.ini",
-      "flake8"
+      "flake8 --config ../backend/uclapi/.flake8.ini"
     ]
   },
   "browserify": {

--- a/frontend/src/components/dashboard/App.jsx
+++ b/frontend/src/components/dashboard/App.jsx
@@ -72,7 +72,7 @@ export default class App extends React.Component {
             <Field
               title="Title"
               content={app.name}
-              onSave={(value) => { actions.saveEditTitle(index, value) }}
+              onSave={(value) => { actions.renameProject(index, value) }}
               isSmall
             />
             <Field

--- a/frontend/src/lib/Api.js
+++ b/frontend/src/lib/Api.js
@@ -13,6 +13,7 @@ class Api {
   })
 
   static post = (url, body) => Api.req.post(url, qs.stringify(body))
+  static get = (url) => Api.req.get(url)
 
   static regenToken = async (appId) => {
     const { data: { app: { token } } } = await Api.post(`/regen/`, { app_id: appId })
@@ -69,6 +70,11 @@ class Api {
       app_id: appId,
       scopes,
     })
+    return data
+  }
+
+  static getData = async () => {
+    const { data } = await Api.get(`/apps/`)
     return data
   }
 }

--- a/frontend/src/lib/Api.js
+++ b/frontend/src/lib/Api.js
@@ -1,0 +1,76 @@
+import axios from 'axios'
+import Cookies from 'js-cookie'
+import qs from 'qs'
+
+class Api {
+  static req = axios.create({
+    baseURL: `/dashboard/api`,
+    withCredentials: true,
+    headers: {
+      'Content-Type': `application/x-www-form-urlencoded`,
+      'X-CSRFToken': Cookies.get(`csrftoken`),
+    },
+  })
+
+  static post = (url, body) => Api.req.post(url, qs.stringify(body))
+
+  static regenToken = async (appId) => {
+    const { data: { app: { token } } } = await Api.post(`/regen/`, { app_id: appId })
+    return token
+  }
+
+  static regenVerificationSecret = async (appId) => {
+    const { data: { new_secret } } = await Api.post(`/webhook/refreshsecret/`, { app_id: appId })
+    return new_secret
+  }
+
+  static updateWebhookSettings = async (appId, settings) => {
+    const { data: { ok, message, ...values } } = await Api.post(`/webhook/edit/`, {
+      app_id: appId,
+      ...settings,
+    })
+    if(!ok){
+      throw new Error(message)
+    }
+    return values
+  }
+
+  static addNewProject = async (name) => {
+    const { data: { app } } = await Api.post(`/create/`, { name })
+    return app
+  }
+
+  static deleteProject = async (appId) => {
+    const { data } = await Api.post(`/delete/`, { app_id: appId })
+    return data
+  }
+
+  static renameProject = async (appId, name) => {
+    const { data } = await Api.post(`/rename/`, {
+      app_id: appId,
+      new_name: name,
+    })
+    return data
+  }
+
+  static saveOAuthCallback = async (appId, url) => {
+    const { data: { success, message } } = await Api.post(`/setcallbackurl/`, {
+      app_id: appId,
+      callback_url: url,
+    })
+    if(!success){
+      throw new Error(message)
+    }
+    return success
+  }
+
+  static setScope = async (appId, scopes) => {
+    const { data } = await Api.post(`/updatescopes/`, {
+      app_id: appId,
+      scopes,
+    })
+    return data
+  }
+}
+
+export default Api

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-no-bind */
-import dayjs from 'dayjs'
 import { styles } from 'Layout/data/dashboard_styles.jsx'
 import {
   Button, CardView, Column, ConfirmBox,
@@ -20,27 +19,21 @@ class Dashboard extends React.Component {
   constructor(props) {
     super(props)
 
-    this.DEBUGGING = false
-
-    // Sort the apps by last updated property
-    window.initialData.apps.sort((a, b) => {
-      const dateA = dayjs(a.created)
-      const dateB = dayjs(b.created)
-
-      if (dateA.isBefore(dateB)) {
-        return -1
-      } else if (dateB.isBefore(dateA)) {
-        return 1
-      } else {
-        return 0
-      }
-    })
-
     this.state = {
-      data: window.initialData,
+      data: {
+        name: ``,
+        cn: ``,
+        department: ``,
+        intranet_groups: ``,
+        apps: [],
+      },
       view: `default`,
       toDelete: -1,
     }
+  }
+
+  componentDidMount(){
+    this.getData()
   }
 
   render() {
@@ -173,6 +166,11 @@ class Dashboard extends React.Component {
         <Footer />
       </>
     )
+  }
+
+  getData = async () => {
+    const data = await Api.getData()
+    this.setState({ data })
   }
 
   addNewProject = async (name) => {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-no-bind */
 import dayjs from 'dayjs'
-import Cookies from 'js-cookie'
 import { styles } from 'Layout/data/dashboard_styles.jsx'
 import {
   Button, CardView, Column, ConfirmBox,
@@ -14,11 +13,7 @@ import 'Styles/dashboard.scss'
 import 'Styles/navbar.scss'
 // UI App Component
 import App from '../components/dashboard/App.jsx'
-
-const defaultHeaders = {
-  'Content-Type': `application/x-www-form-urlencoded`,
-  'X-CSRFToken': Cookies.get(`csrftoken`),
-}
+import Api from '../lib/Api.js'
 
 class Dashboard extends React.Component {
 
@@ -52,7 +47,6 @@ class Dashboard extends React.Component {
     const { data: { name, cn, apps }, view, toDelete } = this.state
 
     const actions = {
-      toggleEditTitle: this.toggleEditTitle,
       regenToken: this.regenToken,
       regenVerificationSecret: this.regenVerificationSecret,
       webhook: {
@@ -61,7 +55,7 @@ class Dashboard extends React.Component {
         saveSiteID: this.saveWebhookSiteID,
         saveRoomID: this.saveWebhookRoomID,
       },
-      saveEditTitle: this.saveEditTitle,
+      renameProject: this.renameProject,
       cancelEditTitle: this.cancelEditTitle,
       setScope: this.setScope,
       saveOAuthCallback: this.saveOAuthCallback,
@@ -181,148 +175,139 @@ class Dashboard extends React.Component {
     )
   }
 
-  addNewProject = (name) => {
-    this.queryDashboardAPI(`/dashboard/api/create/`, `name=` + name, (json) => {
-      // For debugging
-      if (this.DEBUGGING) { console.log(json) }
-
-      // Add the new app to the state so it gets rendered
-      const newApp = json.app
-      newApp[`name`] = name
-
-      const { data } = this.state
-      const newData = { ...data }
-      newData.apps.push(newApp)
-
-      // Go to new state visually
-      this.setState({
-        view: `default`,
-        data: newData,
-      })
-    })
-  }
-
-  deleteConfirm = (index) => {
+  addNewProject = async (name) => {
+    const newApp = await Api.addNewProject(name)
+    const { data } = this.state
     this.setState({
-      view: `delete-project`,
-      toDelete: index,
+      view: `default`,
+      data: {
+        ...data,
+        apps: [...data.apps, newApp],
+      },
     })
   }
 
-  deleteProject = (index) => {
+  deleteConfirm = (index) => this.setState({
+    view: `delete-project`,
+    toDelete: index,
+  })
+
+  deleteProject = async (index) => {
     const { data } = this.state
+  
+    try {
+      await Api.deleteProject(data.apps[index].id)
 
-    this.queryDashboardAPI(
-      `/dashboard/api/delete/`,
-      `app_id=` + data.apps[index].id,
-      (json) => {
-        // For debugging
-        if (this.DEBUGGING) { console.log(json) }
-
-        // Remove the deleted app
-        console.log(`deleting index: ` + index)
-        const newData = { ...data }
-        newData.apps.splice(index, 1)
-
-        // Go to default state visually
-        this.setState({
-          toDelete: -1,
-          view: `default`,
-          data: newData,
-        })
+      this.setState({
+        toDelete: -1,
+        view: `default`,
+        data: {
+          ...data,
+          apps: [
+            ...data.apps.slice(0, index),
+            ...data.apps.slice(index + 1),
+          ],
+        },
       })
+    } catch (error) {
+      window.alert(error.message)
+    }
   }
 
-  saveEditTitle = (index, value) => {
+  renameProject = async (index, value) => {
     const { data } = this.state
 
-    this.queryDashboardAPI(
-      `/dashboard/api/rename/`,
-      `new_name=` + value + `&app_id=` + data.apps[index].id,
-      (json) => {
-      if (this.DEBUGGING) { console.log(json) }
-    })
-
-    data.apps[index].name = value
-    this.setState({ data: data })
+    try {
+      await Api.renameProject(data.apps[index].id, value)
+      this.updateAppState(index, { name: value })
+    } catch (error) {
+      window.alert(error.message)
+    }
   }
 
-  saveOAuthCallback = (index, value) => {
+  saveOAuthCallback = async (index, value) => {
     if (value.startsWith(`https://`) || value == ``) {
       const { data } = this.state
-      data.apps[index].oauth.callback_url = value
 
-      this.queryDashboardAPI(
-        `/dashboard/api/setcallbackurl/`,
-        `app_id=` + data.apps[index].id + `&callback_url=` + value,
-        (json) => {
-          const { success, message } = json
-          if(!success){
-            window.alert(message)
-          }
-        }
-      )
-
-      this.setState({ data: data })
+      try {
+        await Api.saveOAuthCallback(data.apps[index].id, value)
+        this.updateAppState(index, {
+          oauth: {
+            ...data.apps[index].oauth,
+            callback_url: value,
+          },
+        })
+      } catch (error) {
+        window.alert(error.message)
+      }
+       
     } else {
       window.alert(`Must start with https://`)
     }
   }
 
-  setScope = (index, scope, value) => {
-    if (this.DEBUGGING) {
-      console.log(`Change app, ` + index + ` scope, ` + scope + ` to ` + value)
+  setScope = async (index, scope, value) => {
+    const { data } = this.state
+
+    const updatedAppState = ({
+      oauth: {
+        ...data.apps[index].oauth,
+        scopes: [
+          ...data.apps[index].oauth.scopes.slice(0, scope),
+          {
+            ...data.apps[index].oauth.scopes[scope],
+            enabled: value,
+          },
+          ...data.apps[index].oauth.scopes.slice(scope + 1),
+        ],
+      },
+    })
+  
+    const { oauth: { scopes } } = updatedAppState
+    const scopesData = scopes.map(scope => ({
+      name: scope.name,
+      checked: scope.enabled,
+    }))
+  
+    try {
+      await Api.setScope(data.apps[index].id, JSON.stringify(scopesData))
+
+      this.updateAppState(index, updatedAppState)
+    } catch (error) {
+      window.alert(error.message)
     }
-    const { data } = this.state
-    const newData = { ...data }
-
-    // Update data
-    newData.apps[index].oauth.scopes[scope].enabled = value
-
-    // Convert scopes into form for backend
-    const scopes = newData.apps[index].oauth.scopes
-    const scopesData = scopes.map(scope =>
-      ({
-        name: scope.name,
-        checked: scope.enabled,
-      }))
-
-    const json = JSON.stringify(scopesData)
-
-    this.queryDashboardAPI(
-      `/dashboard/api/updatescopes/`,
-      `app_id=${newData.apps[index].id}&scopes=${encodeURIComponent(json)}`,
-      (json) => {
-        console.log(json)
-      })
-
-    this.setState({ data: newData })
   }
 
-  regenToken = (index) => {
+  updateAppState = (index, newAppState) => {
     const { data } = this.state
-
-    this.queryDashboardAPI(
-      `/dashboard/api/regen/`,
-      `app_id=` + data.apps[index].id,
-      (json) => {
-        data.apps[index].token = json.app.token
-        this.setState({ data: data })
-      }
-    )
+    return this.setState({
+      data: {
+        ...data,
+        apps: [
+          ...data.apps.slice(0, index),
+          {
+            ...data.apps[index],
+            ...newAppState,
+          },
+          ...data.apps.slice(index + 1),
+        ],
+      },
+    })
   }
 
-  regenVerificationSecret = (index) => {
+  regenToken = async (index) => {
     const { data } = this.state
+    const token = await Api.regenToken(data.apps[index].id)
+    this.updateAppState(index, { token })
+  }
 
-    this.queryDashboardAPI(
-      `dashboard/api/webhook/refreshsecret/`,
-      `app_id=` + data.apps[index].id,
-      (json) => {
-        data.apps[index].webhook.verification_secret = json.new_secret
-        this.setState({ data: data })
-      }
-    )
+  regenVerificationSecret = async (index) => {
+    const { data } = this.state
+    const secret = await Api.regenVerificationSecret(data.apps[index].id)
+    this.updateAppState(index, { webhook: {
+      ...data.apps[index].webhook,
+      verification_secret: secret,
+    }})
   }
 
   saveWebhookURL = (index, value) => {
@@ -346,56 +331,32 @@ class Dashboard extends React.Component {
     { roomid: value }, index
   )
 
-  updateWebhookSettings = (newValues, index) => {
+  updateWebhookSettings = async (newValues, index) => {
     const { data } = this.state
 
     const app = data.apps[index]
-    const values = {
+    const {
+      url,
+      siteid,
+      roomid,
+      contact,
+    } = {
       ...app.webhook,
       ...newValues,
     }
 
-    const parameters = `url=${
-      values.url
-    }&siteid=${
-      values.siteid
-    }&roomid=${
-      values.roomid
-    }&contact=${
-      values.contact
-    }&app_id=${
-      data.apps[index].id
-    }`
-
-    this.queryDashboardAPI(
-      `dashboard/api/webhook/edit/`,
-      parameters,
-      (json) => {
-        console.log(`For parameters: ` + parameters)
-        const { ok, message } = json
-        if(!ok){
-          window.alert(message)
-        }
-      }
-    )
-
-    data.apps[index].webhook = values
-    this.setState({ data: data })
-  }
-
-  queryDashboardAPI = (url, querystring, callback) => {
-    fetch(url, {
-      method: `POST`,
-      credentials: `include`,
-      headers: defaultHeaders,
-      body: querystring,
-    }).then((res) => {
-      return res.json()
-    }).then(callback)
-      .catch((err) => {
-        console.log(`Failed to save details to: ` + url)
-        console.log(err)
+    try {
+      const result = await Api.updateWebhookSettings(app.id, {
+        url,
+        siteid,
+        roomid,
+        contact,
       })
+
+      this.updateAppState(index, { webhook: result })
+    } catch (error) {
+      window.alert(error.message)
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

This allows the dashboard to exist as a static site on its own. Login and shibboleth is not yet done, but assuming a user is already logged in, a static version of the dashboard would 100% work.

Hound got upset whether I put the line break before or after the `+`, so I've ignored `W503` altogether.

I wrote a test for the new API I put in (`get_apps`), but test coverage for this part of the code is just low, hence the codecov fail.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes


## Anything else
