### PR TITLE
✨ Optionally Allow Bearer Authentication

### DIFF
--- a/backend/uclapi/common/decorators.py
+++ b/backend/uclapi/common/decorators.py
@@ -305,7 +305,18 @@ def uclapi_protected_endpoint(
                     raise UclApiIncorrectDecoratorUsageException
 
             # In any case, a token should be provided
-            token_code = get_var(request, 'token')
+            if 'HTTP_AUTHORIZATION' in request.META:
+                token_code = request.META['HTTP_AUTHORIZATION']
+
+                # To remove the starting BEARER or AUTHENTICATION if provided
+                if ' ' in token_code:
+                    token_code = token_code.split(' ')[1]
+
+                # If multiple tokens provided, for example client_secret
+                if ',' in token_code:
+                    token_code = token_code.split(',')[0]
+            else:
+                token_code = get_var(request, 'token')
             if token_code is None:
                 response = JsonResponse({
                     "ok": False,
@@ -316,7 +327,23 @@ def uclapi_protected_endpoint(
 
             if token_code.startswith('uclapi-user-'):
                 # The token is an OAuth token, so apply OAuth logic
-                client_secret = get_var(request, 'client_secret')
+
+                if 'HTTP_AUTHORIZATION' in request.META:
+                    client_secret = request.META['HTTP_AUTHORIZATION']
+
+                    # To remove the starting BEARER or AUTHENTICATION if provided
+                    if ' ' in token_code:
+                        client_secret = client_secret.split(' ')[1]
+
+                    # Check if the bearer contains the client_secret
+                    if ',' in token_code:
+                        client_secret = client_secret.split(',')[1]
+                    else:
+                        # If not provided assume it is provided in the query
+                        client_secret = get_var(request, 'client_secret')
+                else:
+                    client_secret = get_var(request, 'client_secret')
+
                 if client_secret is None:
                     response = JsonResponse({
                         "ok": False,


### PR DESCRIPTION
## What does this PR do?
In the long term it will be better to allow bearer authentication along with the traditional query or multipart form currently supported. This is very useful for OpenAPI and the auto filling of tokens, #3118. Bearer auth also has the advantage that we are less likely (via Django or Sentry) log any secrets.

The current form of a bearer auth is:
uclapi-token-here,client-secret-here

A standard bearer token also includes a Bearer or Authentication prefix which is optional:
Bearer uclapi-token-here,client-secret-here

For endpoints without personal data only the uclapi-token needs to be included:
Bearer uclapi-token-here     OR     uclapi-token-here

For example:
Authorization: Bearer uclapi-e41308262f23egc-8069e4a41d8a4d7-0d3911b9342ec5b-65b6150c1bd0d49

In the far distance future this may lay the groundwork for the deprecation of get parameters.

## ✅ Pull Request checklist

- [x] Is this code complete?

## 🚨 Is this a breaking change for API clients?
No