### PR TITLE
Add sn and mail to OAuth user data

### DIFF
--- a/backend/uclapi/oauth/views.py
+++ b/backend/uclapi/oauth/views.py
@@ -488,7 +488,6 @@ def token(request):
 )
 def userdata(request, *args, **kwargs):
     token = kwargs['token']
-    print("Checking student status")
     try:
         get_student_by_upi(
             token.user.employee_id

--- a/backend/uclapi/oauth/views.py
+++ b/backend/uclapi/oauth/views.py
@@ -506,7 +506,9 @@ def userdata(request, *args, **kwargs):
         "upi": token.user.employee_id,
         "scope_number": token.scope.scope_number,
         "is_student": is_student,
-        "ucl_groups": token.user.raw_intranet_groups.split(';')
+        "ucl_groups": token.user.raw_intranet_groups.split(';'),
+        "sn": token.user.sn,
+        "mail": token.user.mail
     }
 
     return PrettyJsonResponse(

--- a/frontend/src/components/documentation/Routes/OAuth/UserData.jsx
+++ b/frontend/src/components/documentation/Routes/OAuth/UserData.jsx
@@ -143,6 +143,18 @@ const UserData = ({ activeLanguage }) => (
           example="ucl-all;ucl-ug;"
           description="A semi-colon delimited string of all UCL intranet groups that the user belongs to"
         />
+        <Cell
+          name="sn"
+          extra="string"
+          example="Mrkvicka"
+          description="Given second name/surname of the user. Can be an empty string."
+        />
+        <Cell
+          name="mail"
+          extra="string"
+          example="martin.mrkvicka.20@ucl.ac.uk"
+          description="Alternative (pretty format) E-mail for the given user."
+        />
       </Table>
     </Topic>
 


### PR DESCRIPTION
## What does this PR do?
- Closes #3230 
- Removes unnecessary print statement in `/oauth/user/data` view.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## :squirrel: Deploy notes
None