### PR TITLE
⬆️ Limit the Scope of Dependabot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## What does this PR do?
-For example: Changes the way we retrieve bookings
+For example: Changes the way we retrieve bookings.
 
 ## ✅ Pull Request checklist
 
@@ -10,7 +10,7 @@ For example: Changes the way we retrieve bookings
 ## 🚨 Is this a breaking change for API clients?
 Yes/No
 
-## 🚀 Deploy notes
+## :squirrel: Deploy notes
 For example: Need to run migrations as part of deployment
 
 ## Anything else

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## What does this PR do?
-For example: Changes the way we retrieve bookings.
+For example: Changes the way we retrieve bookings
 
 ## ✅ Pull Request checklist
 
@@ -10,7 +10,7 @@ For example: Changes the way we retrieve bookings.
 ## 🚨 Is this a breaking change for API clients?
 Yes/No
 
-## :squirrel: Deploy notes
+## 🚀 Deploy notes
 For example: Need to run migrations as part of deployment
 
 ## Anything else

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,28 @@
 version: 2
+
 updates:
-- package-ecosystem: pip
+- package-ecosystem: "pip"
   directory: "/backend/uclapi"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
     time: "08:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
+    timezone: "Europe/London"
+  open-pull-requests-limit: 5
+  reviewers:
+    - "uclapi/ucl-api-team"
+  allow: 
+    - dependency-type: "direct"
+    
+- package-ecosystem: "npm"
   directory: "/frontend"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
     time: "08:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
+    timezone: "Europe/London"
+  open-pull-requests-limit: 5
+  reviewers:
+    - "uclapi/ucl-api-team"
+  allow: 
+    - dependency-type: "direct"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.names, 'dependencies') }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What does this PR do?
Limit the scope of dependabot and require us to review each pull request (and decide to skip, merge, ignore). The aim is to make us review these every single week by reducing the work load.

## ✅ Pull Request checklist

- [x] Is this code complete?

## 🚨 Is this a breaking change for API clients?
No
