### PR TITLE
Use .env file variables in docker-compose

### DIFF
--- a/backend/uclapi/.env.docker.example
+++ b/backend/uclapi/.env.docker.example
@@ -2,20 +2,20 @@
 ## These settings are for the app as a whole, and not for any individual components.
 
 # Secret key for Django to use. Auto-generate this and keep it secret!
-SECRET_KEY=
+SECRET_KEY=iRlsWf2BF2nnNy1zIsZcun6fZX5GGpk0
 # Root of Shibboleth's authentication. The example below might apply to fakeshibboleth;
 # an actual example would be https://uclapi.com/Shibboleth.sso
 # Be careful not to add a final /, as URLs like /Shibboleth.sso//Login will be generated,
 # which will cause Shibboleth errors.
 # To test using fakeshibboleth, use the value http://localhost:8001
 # To automatically use fakeshibboleth's .env file use http://localhost:8001/auto
-SHIBBOLETH_ROOT=http://localhost:8001
+SHIBBOLETH_ROOT=http://localhost:8001/auto
 
 # Whether we are running in production. This defines whether we have debug enabled, etc.
 UCLAPI_PRODUCTION=False
 
 # The domain we are running on. This is used by Django's ALLOWED_HOSTS feature
-UCLAPI_DOMAIN=127.0.0.1
+UCLAPI_DOMAIN=localhost
 
 # Whether we are running behind Amazon's EC2 Elastic Load Balancer. If so, this
 # switches on a feature to fetch the local ipv4 address assigned by EC2 so that
@@ -23,8 +23,10 @@ UCLAPI_DOMAIN=127.0.0.1
 # See https://dryan.com/articles/elb-django-allowed-hosts/ for more info.
 UCLAPI_RUNNING_ON_AWS_ELB=False
 
+UCLAPI_CALLBACK_ALLOWED_PROTOCOLS=https;http
+
 # Set URLs that may not be used as OAuth or Webhook callback URLs (for security reasons).
-FORBIDDEN_CALLBACK_URLS=uclapi.com
+FORBIDDEN_CALLBACK_URLS=uclapi.com;staging.ninja
 
 # URLs that are explicitly whitelisted for OAuth and Webhooks
 WHITELISTED_CALLBACK_URLS=https://live-roombookings.uclapi.com/webhook/;https://hackathon.uclapi.com/callback
@@ -35,7 +37,7 @@ WHITELISTED_CALLBACK_URLS=https://live-roombookings.uclapi.com/webhook/;https://
 DB_UCLAPI_NAME=uclapi
 DB_UCLAPI_USERNAME=uclapi
 DB_UCLAPI_PASSWORD=uclapi_test_password
-DB_UCLAPI_HOST=localhost
+DB_UCLAPI_HOST=db
 DB_UCLAPI_PORT=5432
 DB_UCLAPI_POOL_SIZE=20
 
@@ -52,7 +54,7 @@ DB_ROOMS_PASSWORD=
 DB_CACHE_NAME=uclapi_gencache
 DB_CACHE_USERNAME=uclapi_gencache
 DB_CACHE_PASSWORD=uclapi_gencache_test_password
-DB_CACHE_HOST=localhost
+DB_CACHE_HOST=gencache
 DB_CACHE_PORT=5433
 DB_CACHE_POOL_SIZE=20
 
@@ -71,7 +73,7 @@ KEEN_WRITE_KEY=
 SENTRY_DSN=
 
 # Redis settings
-REDIS_UCLAPI_HOST=localhost
+REDIS_UCLAPI_HOST=redis
 
 # Fill this in with the shibboleth test user. This is used to allow limited
 # access for iOS app store reviewers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,14 +47,12 @@ services:
       - gencache
       - redis
     env_file:
+      # allow setting of some env variables and fallback
+      # to example file for default values
+      - ./backend/uclapi/.env.docker.example
       - ./backend/uclapi/.env
     environment:
-      - SECRET_KEY=iRlsWf2BF2nnNy1zIsZcun6fZX5GGpk0
-      - SHIBBOLETH_ROOT=http://localhost:8001/auto
-      - UCLAPI_PRODUCTION=False
-      - UCLAPI_DOMAIN=localhost:8000
-      - UCLAPI_RUNNING_ON_AWS_ELB=False
-      - UCLAPI_CALLBACK_ALLOWED_PROTOCOLS=https;http
+      # DB/Redis-specific variables should be fixed
       - DB_UCLAPI_NAME=uclapi
       - DB_UCLAPI_USERNAME=uclapi
       - DB_UCLAPI_PASSWORD=uclapi_test_password
@@ -65,11 +63,8 @@ services:
       - DB_CACHE_PASSWORD=uclapi_gencache_test_password
       - DB_CACHE_HOST=gencache
       - DB_CACHE_PORT=5432
-      - ORACLE_HOME=/opt/oracle/instantclient_12_2
       - REDIS_UCLAPI_HOST=redis
-      - FORBIDDEN_CALLBACK_URLS=uclapi.com;staging.ninja
-      - WHITELISTED_CALLBACK_URLS=https://live-roombookings.uclapi.com/webhook/;https://hackathon.uclapi.com/callback
-      - EVENTLET_NOPATCH=True
+
 
   fakeshibboleth:
     build:


### PR DESCRIPTION
## What does this PR do?

Currently, our `docker-compose.yml` file hardcodes a number of environment variables. The variables specified in the `environment` key override those specified in the `.env` file, which can be a cause of unexpected behaviour. For instance, changing `UCLAPI_DOMAIN` or `UCLAPI_PRODUCTION` in the env file would previously have no effect when running the uclapi in docker-compose.

This PR hardcodes in the docker-compose file only the values that are already hardcoded elsewhere in that same file (namely the postgres/redis host, username, password, etc.), and leaves the rest of the environment variables to be specified by `backend/uclapi/.env`, with default values set by `backend/uclapi/.env.example`.

This PR also updates `backend/uclapi/.env.docker.example` to use values that work by default in docker-compose.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## 🚀 Deploy notes

This has no impact on deployment.

## Anything else
