### PR TITLE
Migrate To url-loader

### DIFF
--- a/frontend/src/sass/common/uclapi.scss
+++ b/frontend/src/sass/common/uclapi.scss
@@ -59,7 +59,7 @@ body {
 .splash-parallax {
   /* Create the parallax scrolling effect */
   background-attachment: fixed;
-  background-image: url('~Images/home-page/splash_screen.png');
+  background-image: url('Images/home-page/splash_screen.png');
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
@@ -72,7 +72,7 @@ body {
 .team-parallax {
   /* Create the parallax scrolling effect */
   background-attachment: fixed;
-  background-image: url('~Images/team/teambg.jpg');
+  background-image: url('Images/team/teambg.jpg');
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -38,7 +38,14 @@ module.exports = {
       },
       {
         test: /\.(jpg|png|svg|jpeg)$/,
-        loader: `url-loader`,
+        use: [
+          {
+            loader: `file-loader`,
+            options: {
+              esModule: false,
+            },
+          },
+        ],
       },
     ],
   },

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -65,7 +65,14 @@ module.exports = {
       },
       {
         test: /\.(jpg|png|svg|jpeg)$/,
-        loader: `url-loader`,
+        use: [
+          {
+            loader: `file-loader`,
+            options: {
+              esModule: false,
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## What does this PR do?
Patches the controversial decision by webpack file loader to switch to using unflattened objects.

https://stackoverflow.com/questions/59070216/webpack-file-loader-outputs-object-module