### PR TITLE
frontend webpack: migrate to asset modules

### DIFF
--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -38,15 +38,7 @@ module.exports = {
       },
       {
         test: /\.(jpg|png|svg|jpeg)$/,
-        use: [
-          {
-            loader: `url-loader`,
-            options: {
-              esModule: false,
-              limit: true,
-            },
-          },
-        ],
+        type: `asset/inline`,
       },
     ],
   },

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -65,15 +65,7 @@ module.exports = {
       },
       {
         test: /\.(jpg|png|svg|jpeg)$/,
-        use: [
-          {
-            loader: `url-loader`,
-            options: {
-              esModule: false,
-              limit: true,
-            },
-          },
-        ],
+        type: `asset/inline`,
       },
     ],
   },


### PR DESCRIPTION
## What does this PR do?
Turns out there is yet another way of inlining assets for deployment. This method was added in webpack v5, I really hope this method works with django statics.

You can read more about it here: https://webpack.js.org/guides/asset-modules/