### PR TITLE
backend settings: disable disallow host in sentry

### DIFF
--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -150,6 +150,7 @@ if os.environ.get('SENTRY_DSN'):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.redis import RedisIntegration
+     from sentry.integrations.logging import ignore_logger
 
     def remove_token(event, _):
         scrubbers_keys = ['token', 'client_secret', 'X-RateLimit-Remaining', 'X-RateLimit-Limit',
@@ -179,6 +180,8 @@ if os.environ.get('SENTRY_DSN'):
         send_default_pii=False,
         before_send=remove_token
     )
+    
+    ignore_logger('django.security.DisallowedHost')
 
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),

--- a/backend/uclapi/uclapi/settings.py
+++ b/backend/uclapi/uclapi/settings.py
@@ -150,7 +150,7 @@ if os.environ.get('SENTRY_DSN'):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.redis import RedisIntegration
-     from sentry.integrations.logging import ignore_logger
+    from sentry.integrations.logging import ignore_logger
 
     def remove_token(event, _):
         scrubbers_keys = ['token', 'client_secret', 'X-RateLimit-Remaining', 'X-RateLimit-Limit',
@@ -180,7 +180,6 @@ if os.environ.get('SENTRY_DSN'):
         send_default_pii=False,
         before_send=remove_token
     )
-    
     ignore_logger('django.security.DisallowedHost')
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Disable django.security.DisallowedHost from being reported to sentry.