### PR TITLE
Update Navbar for Desktop and Mobile

### DIFF
--- a/frontend/src/components/layout/Link.jsx
+++ b/frontend/src/components/layout/Link.jsx
@@ -2,10 +2,12 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 
-const variant = {
-    up: { marginTop: `-8px` },
-    middle: { marginTop: 0 },
-    down: { marginTop: `8px` },
+const bounceTransition = {
+    y: {
+        type: `spring`,
+        stiffness: 100,
+        duration: 0.4,
+    },
 }
 
 class Link extends React.Component {
@@ -14,70 +16,50 @@ class Link extends React.Component {
 
         this.state = {
             hover: false,
-            animation: `middle`,
         }
-
-        this.mInterval = null
 
         this.onMouseEnterHandler = this.onMouseEnterHandler.bind(this)
         this.onMouseLeaveHandler = this.onMouseLeaveHandler.bind(this)
-        this.bounce = this.bounce.bind(this)
     }
 
     onMouseEnterHandler() {
         this.setState({
             hover: true,
         })
-
-        this.mInterval = window.setInterval(() => {
-            if (this.state.hover) {
-                this.bounce()
-            }
-        }, 450)
     }
 
     onMouseLeaveHandler() {
-        window.clearInterval(this.mInterval)
-
         this.setState({
             hover: false,
-            animation: `middle`,
-        })
-    }
-
-    bounce() {
-        const { animation } = this.state
-        const newAnimationState = (animation == `middle` || animation == `down`) ? `up` : `down`
-
-        this.setState({
-            animation: newAnimationState,
         })
     }
 
     render() {
-        const { animation } = this.state
+        const { hover } = this.state
+        const {src, link, name} = this.props
 
         if (this.props.isSmall) {
             return (
-                <a href={this.props.link}>
+                <a href={link}>
                     <div className="link-to-page"
                       style={{ borderBottom: `solid #ffffff29 2px`,
-padding: `10px 0 10px 0` }}
+                               padding: `10px 0 10px 0` }}
                       onMouseEnter={this.onMouseEnterHandler}
                       onMouseLeave={this.onMouseLeaveHandler}
                     >
-                        <h1 style={{ border: `none` }} >{this.props.name}</h1>
+                        <img style={{ paddingLeft: `5px`}} src={src} />
+                        <h1 style={{ border: `none`}} >{name}</h1>
                     </div>
                 </a>
             )
         } else {
             return (
                 <div className="link-to-page" onMouseEnter={this.onMouseEnterHandler} onMouseLeave={this.onMouseLeaveHandler} >
-                    <motion.div className="bounce-image" variants={variant}>
-                        <img src={this.props.src} />
+                    <motion.div className="bounce-image" transition={bounceTransition} animate={hover ? {y: [`0%`, `-50%`]} : {y: `0%`}}>
+                        <img src={src} />
                     </motion.div>
-                    <a href={this.props.link}>
-                        <h1>{this.props.name}</h1>
+                    <a href={link}>
+                        <h1>{name}</h1>
                     </a>
                 </div>
             )

--- a/frontend/src/components/layout/NavBar.jsx
+++ b/frontend/src/components/layout/NavBar.jsx
@@ -26,6 +26,11 @@ const links = [
     src: about,
   },
   {
+    name: `marketplace`,
+    link: `/marketplace`,
+    src: market,
+  },
+  {
     name: `documentation`,
     link: `/docs`,
     src: docs,
@@ -34,11 +39,6 @@ const links = [
     name: `dashboard`,
     link: `/dashboard`,
     src: dashboard,
-  },
-  {
-    name: `marketplace`,
-    link: `/marketplace`,
-    src: market,
   },
 ]
 
@@ -73,6 +73,7 @@ class NavBar extends React.Component {
       isMenuHidden: true,
     }
   }
+
   toggleMenu = () => {
     if (this.DEBUGGING) { console.log(`Menu button clicked...`) }
 
@@ -81,6 +82,7 @@ class NavBar extends React.Component {
       isMenuHidden: !isMenuHidden,
     })
   }
+
   handleClick = (event) => {
     if (this.DEBUGGING) {
       console.log(`Click event...`)
@@ -92,6 +94,7 @@ class NavBar extends React.Component {
       this.forceClose()
     }
   }
+
   forceClose = () => {
     const { isMenuHidden } = this.state
 
@@ -103,6 +106,7 @@ class NavBar extends React.Component {
       })
     }
   }
+
   updateDimensions = () => {
     if (window.innerWidth < maxScreen) {
       this.setState({
@@ -116,6 +120,7 @@ class NavBar extends React.Component {
       })
     }
   }
+
   componentDidMount() {
     const { isScroll } = this.props
     if (isScroll) { window.addEventListener(`scroll`, this.updateNavBar) }
@@ -127,11 +132,13 @@ class NavBar extends React.Component {
       isMenuHidden: true,
     })
   }
+
   componentWillUnmount() {
     const { isScroll } = this.props
     if (isScroll) { window.removeEventListener(`scroll`, this.updateNavBar) }
     window.removeEventListener(`click`, this.handleClick)
   }
+
   updateNavBar = () => {
     const scrollTop = window.scrollY
     const { isVisible } = this.state
@@ -154,7 +161,8 @@ class NavBar extends React.Component {
     return <div className="navbar-extras">
       <motion.div
         className="navbarconsistent centered"
-        pose={isVisible ? `shown` : `hidden`}
+        initial="hidden"
+        animate={isVisible ? `shown` : `hidden`}
         variants={toast}
       >
         <a href={`/`}>
@@ -188,10 +196,11 @@ class NavBar extends React.Component {
       {isSmall ? (
         <motion.div
           className="link-titles-menu"
-          pose={isMenuHidden ? `hidden` : `shown`}
+          initial="hidden"
+          animate={isMenuHidden ? `hidden` : `shown`}
           variants={slideDown}
         >
-          {links.map((s, key) => (
+          {[...links].reverse().map((s, key) => (
             <Link key={key} name={s.name} src={s.src} link={s.link} isSmall />
           ))}
         </motion.div>

--- a/frontend/src/pages/Home/HomePage.jsx
+++ b/frontend/src/pages/Home/HomePage.jsx
@@ -91,8 +91,8 @@ class HomePage extends React.Component {
             />
             <TextView
               text={
-                `UCL API is a student-built platform for student `+
-                `developers to improve the student experience of `+
+                `UCL API is a student-built platform for `+
+                `developers to improve the experience of `+
                 `everyone at UCL.`
               }
               heading={2}

--- a/frontend/src/sass/navbar.scss
+++ b/frontend/src/sass/navbar.scss
@@ -71,38 +71,37 @@
 }
 
 .bounce-image {
-  display: inline-block;
   float: left;
-  height: 16px;
-  margin-right: 16px;
+  height: 1em;
   transition-duration: 0.15s;
   transition-property: margin-right;
   transition-timing-function: linear;
-  width: 16px;
+  width: 1em;
 }
 
 .link-to-page {
-  display: inline-block;
+  font-size: 1em;
   float: right;
-  height: 16px;
-  padding: 20px 5px 0;
+  height: 1em;
+  padding: 20px 15px 0 5px;
 
   img {
-    height: 16px;
+    height: 1em;
     margin: 0;
-    width: 16px;
+    width: 1em;
+    vertical-align: middle;
   }
 }
 
 .link-to-page h1 {
-  border: solid;
-  border-color: white;
-  border-width: 0 0 0 1px;
+  display: inline;
   color: white;
+  border: 0 solid white;
+  border-right-width: 1px;
   font-size: 1em;
   font-weight: normal;
   margin: 0;
-  padding: 0 20px;
+  padding: 0 5px 0 5px;
   text-shadow: unset;
   transition-duration: 0.2s;
   transition-property: border-width;
@@ -110,13 +109,8 @@
 }
 
 .link-to-page a {
-  display: inline-block;
   float: left;
   text-decoration: none;
-}
-
-.link-to-page h1:hover {
-  border-width: 0 0 0 5px;
 }
 
 .link-titles {


### PR DESCRIPTION
## What does this PR do?
Fixes the animation bug on mobile preventing the navbar from closing and updates the style. Also fixes the bouncing animation and replaces it with a spring animation. Also fixes the order on mobile so that the most important item is first.

Before, desktop:
![image](https://user-images.githubusercontent.com/5961364/132352593-eae9a657-9983-4f62-b512-c7de2cd7791d.png)

After, desktop:
![image](https://user-images.githubusercontent.com/5961364/132353219-c60f948b-b3ea-4f49-beb7-65e99e10895d.png)

Mobile:
![image](https://user-images.githubusercontent.com/5961364/132352688-1e23d6ba-06f8-4204-b5cc-1449e81b9791.png)

