### PR TITLE
Add Oracle TNS to Docker Oracle Installation

### DIFF
--- a/docker/deployment/uclapi.Dockerfile
+++ b/docker/deployment/uclapi.Dockerfile
@@ -75,6 +75,9 @@ RUN wget -nv -O instantclient.zip ${ORACLE_INSTANTCLIENT_BASIC_URL} && \
     ldconfig && \
     grep -q -F "ORACLE_HOME=${ORACLE_HOME}" /etc/environment || echo "ORACLE_HOME=${ORACLE_HOME}" >> /etc/environment && \
     echo "${ORACLE_HOME}" > /etc/ld.so.conf.d/oracle.conf && \
+    mkdir -p ${ORACLE_HOME}/network/admin/ && \
+    mv ./docker/deployment/oracle/* ${ORACLE_HOME}/network/admin/ && \
+    export TNS_ADMIN=${ORACLE_HOME}/network/admin/ && \
     ldconfig
 
 # Install the Supervisor configuration files


### PR DESCRIPTION
## What does this PR do?
Add TNS files to network/admin for docker

## 🚀 Deploy notes
This will break on production so should *NOT* be deployed (only to staging).