### PR TITLE
libcal: use whitelist for sensitive endpoints instead of blacklist

### DIFF
--- a/backend/uclapi/libcal/tests.py
+++ b/backend/uclapi/libcal/tests.py
@@ -256,8 +256,10 @@ class LibcalNonPersonalEndpointsTestCase(APITestCase):
 
     def test_bookings_personal_information_stripped(self, m):
         """Tests that personal information is stripped from the booking"""
-        json = [{'email': 'delete_me', 'firstName': 'delete_me', 'lastName': 'delete_me', 'bookId': 'delete_me',
-                 'check_in_code': 'delete_me', 'leaveMe': 'leave_me'}]
+        allowed_fields = ['seat_name']
+        json = [{'email': 'delete_me', 'firstName': 'delete_me', 'lastName': 'delete_me',
+                 'bookId': 'delete_me', 'check_in_code': 'delete_me', 'seat_name': 'leave_me',
+                 'random_unknown_key': 'delete_me'}]
         m.register_uri(
             'GET',
             f'https://library-calendars.ucl.ac.uk/1.1/space/bookings?eid=123',
@@ -268,9 +270,13 @@ class LibcalNonPersonalEndpointsTestCase(APITestCase):
             f'/libcal/space/bookings',
             {'ids': 1, 'eid': 123, 'token': self.app.api_token}
         )
-        self.assertEqual(response.status_code, 200)
+
+        # Make sure the number of fields in the returned booking that are not in allowed_fields is 0
+        for booking in response.json()['bookings']:
+            self.assertEqual(len([x for x in booking.keys() if x not in allowed_fields]), 0)
+
         for k, v in response.json()['bookings'][0].items():
-            self.assertEqual(k, 'leave_me')
+            self.assertEqual(k, 'seat_name')
             self.assertEqual(v, 'leave_me')
 
     @parameterized.expand([

--- a/backend/uclapi/libcal/tests_utils.py
+++ b/backend/uclapi/libcal/tests_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from parameterized import parameterized
-from .utils import camelise, cameliser, underscore, underscorer
+from .utils import camelise, cameliser, underscore, underscorer, whitelist_fields
 
 CAMEL_TO_UNDERSCORE = (
     ("product", "product"),
@@ -40,6 +40,11 @@ class TestCameliser(TestCase):
         expected = {'htmlTidy': {'freeBsd': 1}, 'hTML': 2}
         self.assertDictEqual(expected, cameliser(input))
 
+    def test_nested_list(self):
+        data = {'html_tidy': [{'free_bsd': 1}, {'free_bsd': 2}], 'HTML': 2}
+        expected = {'htmlTidy': [{'freeBsd': 1}, {'freeBsd': 2}], 'hTML': 2}
+        self.assertDictEqual(expected, cameliser(data))
+
 
 class TestUnderscore(TestCase):
     @parameterized.expand(CAMEL_TO_UNDERSCORE + CAMEL_TO_UNDERSCORE_WITHOUT_REVERSE)
@@ -57,3 +62,19 @@ class TestUnderscorer(TestCase):
         input = {'htmlTidy': {'FreeBSD': 1}, 'html': 2}
         expected = {'html_tidy': {'free_bsd': 1}, 'html': 2}
         self.assertDictEqual(expected, underscorer(input))
+
+    def test_nested_list(self):
+        data = {'htmlTidy': [{'freeBsd': 1}, {'freeBsd': 2}], 'html': 2}
+        expected = {'html_tidy': [{'free_bsd': 1}, {'free_bsd': 2}], 'html': 2}
+        self.assertDictEqual(expected, underscorer(data))
+
+
+class TestWhitelist(TestCase):
+    def test_whitelist(self):
+        whitelist = ['booking_id', 'arbitrary_field_name', 'field_not_in_data']
+        data = {'booking_id': 1,
+                'arbitrary_field_name': 2,
+                'arbitrary_other_field_name': 3,
+                'super_sensitive_data': 4}
+        expected = {'booking_id': 1, 'arbitrary_field_name': 2}
+        self.assertDictEqual(expected, whitelist_fields(data, whitelist))

--- a/backend/uclapi/libcal/utils.py
+++ b/backend/uclapi/libcal/utils.py
@@ -3,6 +3,22 @@ import re
 NO_CAMEL = ['seat_id']
 
 
+def whitelist_fields(data_dict, desired_fields):
+    """
+    Given a dict and a list of fields, returns the dict with only the provided fields, and nothing else.
+
+    Example::
+        >>> whitelist_fields({"email": "test@test.com", "booking_id": "abcdef"}, ["booking_id"])
+        {"booking_id": "abcdef"}
+
+    Use this to sanitise data returned by LibCal to prevent leaking sensitive data.
+    """
+    sanitised_dict = {}
+    for field in desired_fields:
+        if field in data_dict:
+            sanitised_dict[field] = data_dict[field]
+    return sanitised_dict
+
 def underscore(word):
     """
     Make an underscored, lowercase form from the expression in the string.

--- a/uclapi.openapi.json
+++ b/uclapi.openapi.json
@@ -529,7 +529,8 @@
           "category_name": { "$ref": "#/components/schemas/libcal_category_name" },
           "item_name": { "$ref": "#/components/schemas/libcal_space_name" },
           "seat_id": { "$ref": "#/components/schemas/libcal_seat_id" },
-          "seat_name": { "$ref": "#/components/schemas/libcal_seat_name" }
+          "seat_name": { "$ref": "#/components/schemas/libcal_seat_name" },
+          "cancelled": { "$ref": "#/components/schemas/libcal_cancelled" }
         }
       },
       "libcal_location_id": {
@@ -546,6 +547,11 @@
         "type": "string",
         "description": "Name of the LibCal seat",
         "example": "367 - Donaldson Reading Room (Law)"
+      },
+      "libcal_cancelled": {
+        "type": "string",
+        "description": "Timestamp (in ISO 8601 format) at which this LibCal booking was cancelled, if applicable",
+        "example": "2021-01-14T09:00:00+00:00"
       },
       "libcal_seat": {
         "properties": {


### PR DESCRIPTION
## What does this PR do?
Change GET bookings for libcal to only allow specific fields, rather than removing certain fields.

This means if the actual libcal endpoint adds any more sensitive fields in future, we won't return them to the user unwittingly.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No
