### PR TITLE
Don't accept OAuth tokens belonging to deleted apps

### DIFF
--- a/backend/uclapi/common/decorators.py
+++ b/backend/uclapi/common/decorators.py
@@ -160,6 +160,16 @@ def _check_oauth_token_issues(token_code, client_secret, required_scopes):
         response.status_code = 400
         return response
 
+    if token.app.deleted:
+        response = JsonResponse({
+            "ok": False,
+            "error":
+                "The token is invalid as the developer has "
+                "deleted their app."
+        })
+        response.status_code = 400
+        return response
+
     scopes = Scopes()
     for s in required_scopes:
         if not scopes.check_scope(token.scope.scope_number, s):

--- a/backend/uclapi/common/decorators.py
+++ b/backend/uclapi/common/decorators.py
@@ -167,7 +167,7 @@ def _check_oauth_token_issues(token_code, client_secret, required_scopes):
                 "The token is invalid as the developer has "
                 "deleted their app."
         })
-        response.status_code = 400
+        response.status_code = 403
         return response
 
     scopes = Scopes()

--- a/backend/uclapi/common/tests.py
+++ b/backend/uclapi/common/tests.py
@@ -495,6 +495,30 @@ class OAuthTokenCheckerTest(TestCase):
             self.valid_oauth_token.token
         )
 
+    def test_deleted_app_valid_token(self):
+        self.valid_oauth_token.active = True
+        self.valid_oauth_token.save()
+        self.valid_app.deleted = True
+        self.valid_app.save()
+
+        result = _check_oauth_token_issues(
+            self.valid_oauth_token.token,
+            self.valid_app.client_secret,
+            ['timetable']
+        )
+        self.assertTrue(isinstance(result, JsonResponse))
+        self.assertEqual(
+            result.status_code,
+            400
+        )
+        data = json.loads(result.content.decode())
+        self.assertFalse(data["ok"])
+        self.assertEqual(
+            data["error"],
+            "The token is invalid as the developer has "
+            "deleted their app."
+        )
+
 
 class LastModifiedHeaderTestCase(TestCase):
     base_redis_key = "http:headers:Last-Modified:"

--- a/backend/uclapi/common/tests.py
+++ b/backend/uclapi/common/tests.py
@@ -509,7 +509,7 @@ class OAuthTokenCheckerTest(TestCase):
         self.assertTrue(isinstance(result, JsonResponse))
         self.assertEqual(
             result.status_code,
-            400
+            403
         )
         data = json.loads(result.content.decode())
         self.assertFalse(data["ok"])


### PR DESCRIPTION
## What does this PR do?
Rejects OAuth tokens if the corresponding app has been deleted.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes/No

## 🚀 Deploy notes
For example: Need to run migrations as part of deployment

## Anything else
