### PR TITLE
remove unnecessary comma after button style definition

### DIFF
--- a/frontend/src/sass/common/uclapi.scss
+++ b/frontend/src/sass/common/uclapi.scss
@@ -239,7 +239,7 @@ a {
 .image-button:hover,
 .uclapi-card-clicked-alternate:hover { background-color: $color-grey-lighter; }
 
-.emphasis-button, {
+.emphasis-button {
   background-color: lighten($primary-highlight-color, 10%);
   color: black;
 }


### PR DESCRIPTION
## What does this PR do?
Removes an unnecessary trailing comma after button definition in uclapi.scss

## ✅ Pull Request checklist

- [x] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## 🚀 Deploy notes
N/A

## Anything else

Closes #3453 