### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/docker/deployment/uclapi.Dockerfile
+++ b/docker/deployment/uclapi.Dockerfile
@@ -25,26 +25,26 @@ WORKDIR /web
 COPY ./docker/deployment/non-public/${ENVIRONMENT}/uclapi/uclfw.rules /web/uclfw.rules
 
 RUN apt-get update && \
-    apt-get install -y python3 \
-                       python3-wheel \
-                       python3-setuptools \
-                       libaio1 \
-                       wget \
-                       git \
-                       libpq-dev \
-                       libpq5 \
-                       libpython3-dev \
-                       unzip \
-                       build-essential \
-                       libpcre3 \
-                       libpcre3-dev \
-                       sed \
-                       supervisor \
-                       liblz4-1 &&\
+    apt-get install -y python3=3.8.* \ 
+                       python3-wheel=0.34.* \ 
+                       python3-setuptools=45.2.* \ 
+                       libaio1=0.3.* \ 
+                       wget=1.20.* \ 
+                       git=1:2.25.* \ 
+                       libpq-dev=12.14-* \ 
+                       libpq5=12.14-* \ 
+                       libpython3-dev=3.8.* \ 
+                       unzip=6.0-* \ 
+                       build-essential=12.8ubuntu1.* \ 
+                       libpcre3=2:8.39-* \ 
+                       libpcre3-dev=2:8.39-* \ 
+                       sed=4.7-* \ 
+                       supervisor=4.1.* \ 
+                       liblz4-1=1.9.* &&\ 
     apt-get clean
 
 # Fix up the language / encoding environment variables to stop Pip complaining later
-RUN apt-get install locales && locale-gen en_GB.UTF-8
+RUN apt-get install locales=2.31-* && locale-gen en_GB.UTF-8 
 ENV LANG en_GB.UTF-8
 ENV LANGUAGE en_GB:en
 ENV LC_ALL en_GB.UTF-8


### PR DESCRIPTION
## What does this PR do?
Version pinning for installed apt packages

## ✅ Pull Request checklist

- [x] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes

## 🚀 Deploy notes
For example: Need to run migrations as part of deployment

## Anything else
Hi!
The Dockerfile placed at "docker/deployment/uclapi.Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance