### PR TITLE
Account for some AD groups not having the mailNickname

### DIFF
--- a/backend/uclapi/oauth/app_helpers.py
+++ b/backend/uclapi/oauth/app_helpers.py
@@ -139,10 +139,14 @@ def validate_azure_ad_callback(token_data):
     display_name = given_name + ' ' + sn
 
     # e.g., engscifac-all;compsci-all;schsci-all
-    groups = ';'.join(map(
-        lambda g: g.get('onPremisesSamAccountName') or g['mailNickname'],
+    group_names = map(
+        lambda g: g.get('onPremisesSamAccountName') or g.get('mailNickname'),
         user_groups.get('value', [])
-    ))
+    )
+
+    # Some groups don't have either of the above field names,
+    # e.g., #microsoft.graph.directoryRole -- we don't want these
+    groups = ';'.join([name for name in group_names if name is not None])
 
     mail = user_info.get('mail', '')  # e.g., firstname.lastname.year@ucl.ac.uk
 


### PR DESCRIPTION
## What does this PR do?
Groups of type #microsoft.graph.directoryRole and maybe more don't have `onPremisesSamAccountName` nor `mailNickname` properties. We can ignore these because they aren't the type of groups we want.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No

## 🚀 Deploy notes

## Anything else
