### PR TITLE
Return 403 for tokens with insufficient scope

### DIFF
--- a/backend/uclapi/common/decorators.py
+++ b/backend/uclapi/common/decorators.py
@@ -179,7 +179,7 @@ def _check_oauth_token_issues(token_code, client_secret, required_scopes):
                     "The token provided does not have "
                     "permission to access this data."
             })
-            response.status_code = 400
+            response.status_code = 403
             return response
 
     # Return the token as there are no issues

--- a/backend/uclapi/common/tests.py
+++ b/backend/uclapi/common/tests.py
@@ -470,7 +470,7 @@ class OAuthTokenCheckerTest(TestCase):
         self.assertTrue(isinstance(result, JsonResponse))
         self.assertEqual(
             result.status_code,
-            400
+            403
         )
         data = json.loads(result.content.decode())
         self.assertFalse(data["ok"])

--- a/backend/uclapi/oauth/tests.py
+++ b/backend/uclapi/oauth/tests.py
@@ -318,7 +318,7 @@ class OAuthTokenCheckDecoratorTestCase(TestCase):
         response = test_timetable_request(request)
         content = json.loads(response.content.decode())
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 403)
         self.assertFalse(content["ok"])
         self.assertEqual(
             content["error"],

--- a/uclapi.openapi.json
+++ b/uclapi.openapi.json
@@ -2240,6 +2240,21 @@
               }
             }
           },
+          "403": {
+            "description": "Permission error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                },
+                "examples": {
+                  "1": {
+                    "$ref": "#/components/examples/ErrorRejectedScope"
+                  }
+                }
+              }
+            }
+          },
           "400": {
             "description": "Request error",
             "content": {
@@ -2271,9 +2286,6 @@
                   },
                   "8": {
                     "$ref": "#/components/examples/ErrorPersonalData"
-                  },
-                  "9": {
-                    "$ref": "#/components/examples/ErrorRejectedScope"
                   }
                 }
               }


### PR DESCRIPTION
## What does this PR do?
Return 403 for tokens with insufficient scope

This is used in the UCL Assistant app to trigger re-login request if an updated scope is required.
400 is too generic for this specific error

## ✅ Pull Request checklist

- [x] Is this code complete?
- [x] Are tests done/modified?
- [x] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
Yes/No

## 🚀 Deploy notes
For example: Need to run migrations as part of deployment

## Anything else
