### PR TITLE
Don't assume employee_type and surname are non-null

### DIFF
--- a/backend/uclapi/oauth/app_helpers.py
+++ b/backend/uclapi/oauth/app_helpers.py
@@ -133,10 +133,10 @@ def validate_azure_ad_callback(token_data):
     # e.g., Dept of Computer Science
     department = user_info.get('department', '')
     given_name = user_info.get('givenName', '')  # e.g. Firstname
-    sn = user_info.get('surname', '')
+    sn = user_info.get('surname') or ''  # Some accounts e.g., 'Equity & Inclusion Officer' don't have surnames
 
     # Concatenate firstname and last name. Azure AD returns displayName as "Surname, Forename" which we don't want
-    display_name = given_name + ' ' + sn
+    display_name = given_name + (f' {sn}' if sn else '')
 
     # e.g., engscifac-all;compsci-all;schsci-all
     group_names = map(
@@ -152,7 +152,8 @@ def validate_azure_ad_callback(token_data):
 
     # Convert comma-separated-with-space string into semicolon-separated string (for consistency with the groups field)
     # e.g., Alumnus;Staff;P/G;Honorary
-    user_types = ';'.join(user_info.get('employeeType', '').split(', '))
+    employee_type = user_info.get('employeeType') or ''
+    user_types = ';'.join(employee_type.split(', '))
 
     # If a user has never used the API before then we need to sign them up
     try:


### PR DESCRIPTION
## What does this PR do?
Some users don't have any employee type or surname. But Graph returns the JSON `null`, so `dict.get()` returns None, but we want to default to `''`.

## ✅ Pull Request checklist

- [x] Is this code complete?
- [ ] Are tests done/modified?
- [ ] Are docs written for this PR? (if applicable)

## 🚨 Is this a breaking change for API clients?
No
